### PR TITLE
feat(extension) Use the new parameters API

### DIFF
--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -74,6 +74,11 @@ PHP_FUNCTION(wasm_read_bytes)
     ZEND_PARSE_PARAMETERS_END();
 
     FILE *wasm_file = fopen(file_path, "r");
+
+    if (wasm_file == NULL) {
+        RETURN_NULL();
+    }
+
     fseek(wasm_file, 0, SEEK_END);
 
     size_t wasm_file_length = ftell(wasm_file);

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -157,15 +157,21 @@ PHP_FUNCTION(wasm_new_instance)
  * `wasm_get_function_signature`.
  */
 
+ZEND_BEGIN_ARG_INFO(arginfo_wasm_get_function_signature, 0)
+    ZEND_ARG_TYPE_INFO(0, wasm_instance, IS_RESOURCE, 0)
+    ZEND_ARG_TYPE_INFO(0, function_name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 PHP_FUNCTION(wasm_get_function_signature)
 {
     zval *wasm_instance_resource;
     char *function_name;
     size_t function_name_length;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "rs", &wasm_instance_resource, &function_name, &function_name_length) == FAILURE) {
-        return;
-    }
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 2, 2);
+        Z_PARAM_RESOURCE(wasm_instance_resource);
+        Z_PARAM_STRING(function_name, function_name_length);
+    ZEND_PARSE_PARAMETERS_END();
 
     wasmer_instance_t *wasm_instance = wasm_instance_from_resource(Z_RES_P(wasm_instance_resource));
     wasmer_exports_t *wasm_exports = NULL;
@@ -427,11 +433,6 @@ PHP_MINFO_FUNCTION(wasm)
     php_info_print_table_header(2, "wasm support", "enabled");
     php_info_print_table_end();
 }
-
-ZEND_BEGIN_ARG_INFO(arginfo_wasm_get_function_signature, 0)
-    ZEND_ARG_TYPE_INFO(0, wasm_instance, IS_RESOURCE, 0)
-    ZEND_ARG_TYPE_INFO(0, function_name, IS_STRING, 0)
-ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_wasm_value, 0)
     ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -316,6 +316,12 @@ PHP_FUNCTION(wasm_value)
  * `wasm_invoke_function`.
  */
 
+ZEND_BEGIN_ARG_INFO(arginfo_wasm_invoke_function, 0)
+    ZEND_ARG_TYPE_INFO(0, wasm_instance, IS_RESOURCE, 0)
+    ZEND_ARG_TYPE_INFO(0, function_name, IS_STRING, 0)
+    ZEND_ARG_ARRAY_INFO(0, inputs, 0)
+ZEND_END_ARG_INFO()
+
 PHP_FUNCTION(wasm_invoke_function)
 {
     zval *wasm_instance_resource;
@@ -323,18 +329,11 @@ PHP_FUNCTION(wasm_invoke_function)
     size_t function_name_length;
     HashTable *inputs;
 
-    if (
-        zend_parse_parameters(
-            ZEND_NUM_ARGS() TSRMLS_CC,
-            "rsh",
-            &wasm_instance_resource,
-            &function_name,
-            &function_name_length,
-            &inputs
-        ) == FAILURE
-    ) {
-        return;
-    }
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 3, 3)
+        Z_PARAM_RESOURCE(wasm_instance_resource)
+        Z_PARAM_STRING(function_name, function_name_length)
+        Z_PARAM_ARRAY_HT(inputs)
+    ZEND_PARSE_PARAMETERS_END();
 
     wasmer_instance_t *wasm_instance = wasm_instance_from_resource(Z_RES_P(wasm_instance_resource));
 
@@ -439,12 +438,6 @@ PHP_MINFO_FUNCTION(wasm)
     php_info_print_table_header(2, "wasm support", "enabled");
     php_info_print_table_end();
 }
-
-ZEND_BEGIN_ARG_INFO(arginfo_wasm_invoke_function, 0)
-    ZEND_ARG_TYPE_INFO(0, wasm_instance, IS_RESOURCE, 0)
-    ZEND_ARG_TYPE_INFO(0, function_name, IS_STRING, 0)
-    ZEND_ARG_ARRAY_INFO(0, inputs, 0)
-ZEND_END_ARG_INFO()
 
 static const zend_function_entry wasm_functions[] = {
     PHP_FE(wasm_read_bytes,				arginfo_wasm_read_bytes)

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -60,14 +60,18 @@ static void wasm_bytes_destructor(zend_resource *resource)
     free(wasm_byte_array);
 }
 
+ZEND_BEGIN_ARG_INFO(arginfo_wasm_read_bytes, 0)
+    ZEND_ARG_TYPE_INFO(0, file_path, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 PHP_FUNCTION(wasm_read_bytes)
 {
-    char *file_path;
-    size_t file_path_length;
+    char *file_path = NULL;
+    size_t file_path_length = 0;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "p", &file_path, &file_path_length) == FAILURE) {
-        return;
-    }
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 1);
+        Z_PARAM_PATH(file_path, file_path_length);
+    ZEND_PARSE_PARAMETERS_END();
 
     FILE *wasm_file = fopen(file_path, "r");
     fseek(wasm_file, 0, SEEK_END);
@@ -414,10 +418,6 @@ PHP_MINFO_FUNCTION(wasm)
     php_info_print_table_header(2, "wasm support", "enabled");
     php_info_print_table_end();
 }
-
-ZEND_BEGIN_ARG_INFO(arginfo_wasm_read_bytes, 0)
-    ZEND_ARG_TYPE_INFO(0, file_path, IS_STRING, 0)
-ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_wasm_new_instance, 0, 0, 1)
     ZEND_ARG_TYPE_INFO(0, wasm_bytes, IS_RESOURCE, 0)

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -66,8 +66,8 @@ ZEND_END_ARG_INFO()
 
 PHP_FUNCTION(wasm_read_bytes)
 {
-    char *file_path = NULL;
-    size_t file_path_length = 0;
+    char *file_path;
+    size_t file_path_length;
 
     ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 1);
         Z_PARAM_PATH(file_path, file_path_length);
@@ -267,14 +267,20 @@ static void wasm_value_destructor(zend_resource *resource)
     free(wasm_value);
 }
 
+ZEND_BEGIN_ARG_INFO(arginfo_wasm_value, 0)
+    ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+    ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+
 PHP_FUNCTION(wasm_value)
 {
     zend_long value_type;
     zval *value;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "lz", &value_type, &value) == FAILURE) {
-        return;
-    }
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 2, 2);
+        Z_PARAM_LONG(value_type);
+        Z_PARAM_ZVAL(value);
+    ZEND_PARSE_PARAMETERS_END();
 
     if (value_type < 0) {
         RETURN_NULL();
@@ -433,11 +439,6 @@ PHP_MINFO_FUNCTION(wasm)
     php_info_print_table_header(2, "wasm support", "enabled");
     php_info_print_table_end();
 }
-
-ZEND_BEGIN_ARG_INFO(arginfo_wasm_value, 0)
-    ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
-    ZEND_ARG_INFO(0, value)
-ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_wasm_invoke_function, 0)
     ZEND_ARG_TYPE_INFO(0, wasm_instance, IS_RESOURCE, 0)

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -69,8 +69,8 @@ PHP_FUNCTION(wasm_read_bytes)
     char *file_path;
     size_t file_path_length;
 
-    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 1);
-        Z_PARAM_PATH(file_path, file_path_length);
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 1)
+        Z_PARAM_PATH(file_path, file_path_length)
     ZEND_PARSE_PARAMETERS_END();
 
     FILE *wasm_file = fopen(file_path, "r");
@@ -128,8 +128,8 @@ PHP_FUNCTION(wasm_new_instance)
 {
     zval *wasm_bytes_resource;
 
-    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 1);
-        Z_PARAM_RESOURCE(wasm_bytes_resource);
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 1)
+        Z_PARAM_RESOURCE(wasm_bytes_resource)
     ZEND_PARSE_PARAMETERS_END();
 
     wasmer_byte_array *wasm_byte_array = wasm_bytes_from_resource(Z_RES_P(wasm_bytes_resource));
@@ -168,9 +168,9 @@ PHP_FUNCTION(wasm_get_function_signature)
     char *function_name;
     size_t function_name_length;
 
-    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 2, 2);
-        Z_PARAM_RESOURCE(wasm_instance_resource);
-        Z_PARAM_STRING(function_name, function_name_length);
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 2, 2)
+        Z_PARAM_RESOURCE(wasm_instance_resource)
+        Z_PARAM_STRING(function_name, function_name_length)
     ZEND_PARSE_PARAMETERS_END();
 
     wasmer_instance_t *wasm_instance = wasm_instance_from_resource(Z_RES_P(wasm_instance_resource));
@@ -277,9 +277,9 @@ PHP_FUNCTION(wasm_value)
     zend_long value_type;
     zval *value;
 
-    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 2, 2);
-        Z_PARAM_LONG(value_type);
-        Z_PARAM_ZVAL(value);
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 2, 2)
+        Z_PARAM_LONG(value_type)
+        Z_PARAM_ZVAL(value)
     ZEND_PARSE_PARAMETERS_END();
 
     if (value_type < 0) {

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -120,13 +120,17 @@ static void wasm_instance_destructor(zend_resource *resource)
     wasmer_instance_destroy(wasm_instance);
 }
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_wasm_new_instance, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, wasm_bytes, IS_RESOURCE, 0)
+ZEND_END_ARG_INFO()
+
 PHP_FUNCTION(wasm_new_instance)
 {
     zval *wasm_bytes_resource;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &wasm_bytes_resource) == FAILURE) {
-        return;
-    }
+    ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 1);
+        Z_PARAM_RESOURCE(wasm_bytes_resource);
+    ZEND_PARSE_PARAMETERS_END();
 
     wasmer_byte_array *wasm_byte_array = wasm_bytes_from_resource(Z_RES_P(wasm_bytes_resource));
     wasmer_instance_t *wasm_instance = NULL;
@@ -423,10 +427,6 @@ PHP_MINFO_FUNCTION(wasm)
     php_info_print_table_header(2, "wasm support", "enabled");
     php_info_print_table_end();
 }
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_wasm_new_instance, 0, 0, 1)
-    ZEND_ARG_TYPE_INFO(0, wasm_bytes, IS_RESOURCE, 0)
-ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_wasm_get_function_signature, 0)
     ZEND_ARG_TYPE_INFO(0, wasm_instance, IS_RESOURCE, 0)


### PR DESCRIPTION
This patch replaces the old parameters API by the new one, as presented in https://phpinternals.net/categories/zend_parameter_parsing.

Bonus: All functions return a `TypeError` when the types don't match.

cc @Ocramius