### PR TITLE
feat: Implement `wasm_compile` and `wasm_module_new_instance`

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -69,6 +69,18 @@ $module = wasm_compile($bytes);
 
 This function returns a resource of type `wasm_module`.
 
+### Function `wasm_module_new_instance`
+
+Instantiates a WebAssembly module:
+
+```php
+$bytes = wasm_read_bytes('my_program.wasm');
+$module = wasm_compile($bytes);
+$instance = wasm_module_new_instance($module);
+```
+
+This function returns a resource of type `wasm_instance`.
+
 ### Function `wasm_new_instance`
 
 Compiles and instantiates WebAssembly bytes:
@@ -80,6 +92,8 @@ $instance = wasm_new_instance($bytes);
 
 This function returns a resource of type `wasm_instance`.
 
+This function combines `wasm_compile` and
+`wasm_module_new_instance`. It “hides” the module.
 
 ### Function `wasm_get_function_signature`
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -45,7 +45,7 @@ This function returns a resource of type `wasm_bytes`.
 
 ### Function `wasm_validate`
 
-Validate bytes from the `wasm_read_bytes` function:
+Validates bytes from the `wasm_read_bytes` function:
 
 ```php
 $bytes = wasm_read_bytes('my_program.wasm');
@@ -57,6 +57,17 @@ if (false === wasm_validate($bytes)) {
 
 This function returns `true` when the bytes are valid, `false`
 otherwise.
+
+### Function `wasm_compile`
+
+Compiles bytes into a WebAssembly module.
+
+```php
+$bytes = wasm_read_bytes('my_program.wasm');
+$module = wasm_compile($bytes);
+```
+
+This function returns a resource of type `wasm_module`.
 
 ### Function `wasm_new_instance`
 


### PR DESCRIPTION
Fix #16.

Basic usage:

```php
$bytes = wasm_read_bytes('my_program.wasm');
$module = wasm_compile($bytes);
$instance = wasm_module_new_instance($module);
```

Thus, `wasm_new_instance` is just a shortcut of `wasm_compile` + `wasm_module_new_instance`, except that the module is “hidden”.

This patch implements these two functions, add tests, and add the documentation.

These functions are not used yet in the `Wasm` library.