### PR TITLE
feat: Add the `Module` class and API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
     },
     "scripts": {
         "test": "vendor/bin/atoum --php 'php -d extension=wasm' --directories tests/units --force-terminal",
-        "doc": "php -d extension=wasm vendor/bin/kitab compile --with-composer --with-project-name=php-ext-wasm --output-directory doc lib"
+        "doc": "php -d extension=wasm vendor/bin/kitab compile --with-composer --with-project-name=php-ext-wasm --with-logo-url='https://github.com/wasmerio.png' --output-directory doc lib"
     }
 }

--- a/lib/Instance.php
+++ b/lib/Instance.php
@@ -12,6 +12,20 @@ use RuntimeException;
  * The `Instance` class allows to compile WebAssembly bytes into a module, and
  * instantiate the module directly. Then, it is possible to call exported
  * functions with a user-friendly API.
+ *
+ * To get a ready to use WebAssembly program, one first needs to compile the
+ * bytes into a module, and second to instantiate the module. This class
+ * allows to combine these two steps: The constructor compiles and
+ * instantiates the module in a single-pass.
+ *
+ * # Examples
+ *
+ * ```php,ignore
+ * $instance = new Wasm\Instance('my_program.wasm');
+ * $result = $instance->sum(1, 2);
+ * ```
+ *
+ * That simple.
  */
 class Instance
 {
@@ -33,14 +47,6 @@ class Instance
      *
      * The constructor also throws a `RuntimeException` when the compilation
      * or the instantiation failed.
-     *
-     * # Examples
-     *
-     * ```php,ignore
-     * $instance = new Wasm\Instance('my_program.wasm');
-     * ```
-     *
-     * That simple.
      */
     public function __construct(string $filePath)
     {
@@ -77,9 +83,20 @@ class Instance
      * Instantiates a WebAssembly module.
      *
      * This method throws a `RuntimeException` when the instantiation failed.
+     *
+     * # Examples
+     *
+     * ```php,ignore
+     * $module = new Wasm\Module('my_program.wasm');
+     * $instance = Wasm\Instance::fromModule($module);
+     * $result = $instance->sum(1, 2);
+     * ```
      */
     public static function fromModule(Module $module): self
     {
+        // Using an anonymous class allows to overwrite the constructor,
+        // and to inject the `wasm_instance` resource and the file path.
+        // From a type point of view, there is no difference.
         return new class($module) extends Instance {
             public function __construct(Module $module) {
                 $this->filePath = $module->getFilePath();

--- a/lib/Module.php
+++ b/lib/Module.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Wasm;
+
+use RuntimeException;
+
+/**
+ * The `Module` class allows to compile WebAssembly bytes into a WebAssembly
+ * module.
+ */
+class Module
+{
+    /**
+     * The file path to the Wasm binary file.
+     */
+    private $filePath;
+
+    /**
+     * The Wasm module.
+     */
+    private $wasmModule;
+
+    /**
+     */
+    public function __construct(string $filePath)
+    {
+        if (false === file_exists($filePath)) {
+            throw new RuntimeException("File path to Wasm binary `$filePath` does not exist.");
+        }
+
+        if (false === is_readable($filePath)) {
+            throw new RuntimeException("File `$filePath` is not readable.");
+        }
+
+        $this->filePath = $filePath;
+        $wasmBytes = wasm_read_bytes($this->filePath);
+
+        if (null === $wasmBytes) {
+            throw new RuntimeException("An error happened while reading the module `$filePath`.");
+        }
+
+        if (false === wasm_validate($wasmBytes)) {
+            throw new RuntimeException("Bytes in `$filePath` are invalid.");
+        }
+
+        $this->wasmModule = wasm_compile($wasmBytes);
+
+        if (null === $this->wasmModule) {
+            throw new RuntimeException(
+                "An error happened while compiling the module `$filePath`:\n    " .
+                str_replace("\n", "\n    ", wasm_get_last_error())
+            );
+        }
+    }
+
+    public function instantiate(): Instance
+    {
+        return Instance::fromModule($this);
+    }
+
+    /**
+     * Returns the file path given to the constructor.
+     */
+    public function getFilePath(): string
+    {
+        return $this->filePath;
+    }
+
+    /**
+     * Returns the inner resource representing the module.
+     */
+    public function intoResource()
+    {
+        return $this->wasmModule;
+    }
+}

--- a/lib/Module.php
+++ b/lib/Module.php
@@ -9,6 +9,19 @@ use RuntimeException;
 /**
  * The `Module` class allows to compile WebAssembly bytes into a WebAssembly
  * module.
+ *
+ * To get a ready to use WebAssembly program, one first needs to compile the
+ * bytes into a module, and second to instantiate the module. This class
+ * addresses the first step. To instantiate the module, call the `instantiate`
+ * method.
+ *
+ * # Examples
+ *
+ * ```php,ignore
+ * $module = new Wasm\Module('my_program.wasm');
+ * $instance = $module->instantiate();
+ * $result = $instance->sum(1, 2);
+ * ```
  */
 class Module
 {
@@ -23,6 +36,13 @@ class Module
     private $wasmModule;
 
     /**
+     * Compiles WebAssembly bytes from a file into a module.
+     *
+     * The constructor throws a `RuntimeException` when the given file does
+     * not exist, or is not readable.
+     *
+     * The constructor also throws a `RuntimeException` when the compilation
+     * failed.
      */
     public function __construct(string $filePath)
     {
@@ -55,6 +75,25 @@ class Module
         }
     }
 
+    /**
+     * Instantiates the module.
+     *
+     * # Examples
+     *
+     * The following code:
+     *
+     * ```php,ignore
+     * $module = new Wasm\Module('my_program.wasm');
+     * $instance = $module->instantiate();
+     * ```
+     *
+     * is a shortcut to:
+     *
+     * ```php,ignore
+     * $module = new Wasm\Module('my_program.wasm');
+     * $instance = Wasm\Instance::fromModule($module);
+     * ```
+     */
     public function instantiate(): Instance
     {
         return Instance::fromModule($this);

--- a/lib/README.md
+++ b/lib/README.md
@@ -6,7 +6,9 @@ that brings more safety and a more user-friendly API.
 This section lists API provided by the `Wasm` library. The entry is
 `Wasm\Instance`.
 
-Let's go through a very basic example. Let's assume this Rust program:
+## Quick example
+
+Let's go through a very quick example. Let's assume this Rust program:
 
 ```rust
 #[no_mangle]
@@ -27,6 +29,40 @@ var_dump($result); // int(3)
 
 This example above calls a function `sum` that is exported from
 `my_program.wasm`.
+
+## The life pattern of a WebAssembly binary, and the API
+
+A WebAssembly file is only a sequence of bytes. In order to get a
+running WebAssembly program:
+
+ 1. These bytes must be compiled into a module,
+ 2. The module must be instantiate.
+ 
+The `Wasm\Module` represents a module. The `Wasm\Instance` represents
+an instance of a module.
+
+So, one can write:
+
+```php
+$module = new Wasm\Module('my_program.wasm');
+$instance = $module->instantiate();
+$result = $instance->sum(1, 2);
+```
+
+Or, alternatively, when having a module is not necessary, one can
+write:
+
+```php
+$instance = new Wasm\Instance('my_program.wasm');
+$result = $instance->sum(1, 2);
+```
+
+Why would one want to get a module? Because it's serializable, and
+thus can be stored in a cache. The bytes compilation to a module can
+be costly depending of the size of your WebAssembly program, and the
+[runtime
+backend](https://github.com/wasmerio/wasmer/tree/master/lib#backends)
+(LLVM, Cranelift etc.).
 
 # The `php-ext-wasm` raw API
 

--- a/tests/units/Instance.php
+++ b/tests/units/Instance.php
@@ -68,7 +68,7 @@ class Instance extends Suite
             )
                 ->isInstanceOf(RuntimeException::class)
                 ->hasMessage(
-                    "An error happened while instanciating the module `$filePath`:\n" .
+                    "An error happened while compiling or instanciating the module `$filePath`:\n" .
                     "    error instantiating"
                 );
     }

--- a/tests/units/Module.php
+++ b/tests/units/Module.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Wasm\Tests\Units;
+
+use RuntimeException;
+use Wasm as LUT;
+use Wasm\Module as SUT;
+use Wasm\Tests\Suite;
+
+class Module extends Suite
+{
+    const FILE_PATH = __DIR__ . '/tests.wasm';
+
+    public function test_constructor_invalid_path()
+    {
+        $this
+            ->given($filePath = '/foo/bar')
+            ->exception(
+                function () use ($filePath) {
+                    new SUT($filePath);
+                }
+            )
+                ->isInstanceOf(RuntimeException::class)
+                ->hasMessage("File path to Wasm binary `$filePath` does not exist.");
+    }
+
+    public function test_constructor_cannot_read_the_module()
+    {
+        $this
+            ->given(
+                $filePath = __DIR__ . '/foo',
+                $this->function->file_exists = true,
+                $this->function->is_readable = true
+            )
+            ->exception(
+                function () use ($filePath) {
+                    new SUT($filePath);
+                }
+            )
+                ->isInstanceOf(RuntimeException::class)
+                ->hasMessage("An error happened while reading the module `$filePath`.");
+    }
+
+    public function test_constructor_invalid_bytes()
+    {
+        $this
+            ->given($filePath = __DIR__ . '/invalid.wasm')
+            ->exception(
+                function () use ($filePath) {
+                    new SUT($filePath);
+                }
+            )
+                ->isInstanceOf(RuntimeException::class)
+                ->hasMessage("Bytes in `$filePath` are invalid.");
+    }
+
+    public function test_constructor_invalid_compilation()
+    {
+        $this
+            ->given(
+                $filePath = __DIR__ . '/empty.wasm',
+                $this->function->wasm_validate = true
+            )
+            ->exception(
+                function () use ($filePath) {
+                    new SUT($filePath);
+                }
+            )
+                ->isInstanceOf(RuntimeException::class)
+                ->hasMessage(
+                    "An error happened while compiling the module `$filePath`:\n" .
+                    "    Validation error \"Unexpected EOF\""
+                );
+    }
+
+    public function test_instantiate()
+    {
+        $this
+            ->given($module = new SUT(static::FILE_PATH))
+            ->when($result = $module->instantiate())
+            ->then
+                ->object($result)
+                    ->isInstanceOf(LUT\Instance::class)
+                ->integer($result->sum(1, 2))
+                    ->isEqualTo(3);
+    }
+
+    public function test_get_file_path()
+    {
+        $this
+            ->given(
+                $filePath = static::FILE_PATH,
+                $module = new SUT($filePath)
+            )
+            ->when($result = $module->getFilePath())
+            ->then
+                ->string($result)
+                    ->isEqualTo($filePath);
+    }
+
+    public function test_into_resource()
+    {
+        $this
+            ->given($module = new SUT(static::FILE_PATH))
+            ->when($result = $module->intoResource())
+            ->then
+                ->resource($result)
+                    ->isOfType('wasm_module');
+    }
+}


### PR DESCRIPTION
This PR implements the `Module` class. The API basically the following:

```php
$module = new Wasm\Module('my_program.wasm');
$instance = $module->instantiate();
$result = $instance->sum(1, 2);
```

Documentation and tests are updated.