### PR TITLE
feat: Implement the `wasm_module_serialize` and `wasm_module_deserialize` functions

### DIFF
--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -306,20 +306,16 @@ ZEND_END_ARG_INFO()
  */
 PHP_FUNCTION(wasm_module_deserialize)
 {
-    char *serialized_module;
-    size_t serialized_module_length;
+    char *wasm_serialized_module_bytes;
+    size_t wasm_serialized_module_bytes_length;
 
     ZEND_PARSE_PARAMETERS_START_EX(ZEND_PARSE_PARAMS_THROW, 1, 1)
-        Z_PARAM_STRING(serialized_module, serialized_module_length)
+        Z_PARAM_STRING(wasm_serialized_module_bytes, wasm_serialized_module_bytes_length)
     ZEND_PARSE_PARAMETERS_END();
-
-    wasmer_byte_array wasm_serialized_module_bytes;
-    wasm_serialized_module_bytes.bytes = (const uint8_t *) serialized_module;
-    wasm_serialized_module_bytes.bytes_len = serialized_module_length;
 
     wasmer_serialized_module_t *wasm_serialized_module = NULL;
 
-    if (wasmer_serialized_module_from_bytes(&wasm_serialized_module, &wasm_serialized_module_bytes) != wasmer_result_t::WASMER_OK) {
+    if (wasmer_serialized_module_from_bytes(&wasm_serialized_module, (const uint8_t *) wasm_serialized_module_bytes, wasm_serialized_module_bytes_length) != wasmer_result_t::WASMER_OK) {
         RETURN_NULL();
     }
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -105,6 +105,37 @@ $module = wasm_compile($bytes);
 
 This function returns a resource of type `wasm_module`.
 
+### Function `wasm_module_serialize`
+
+Serializes a module into a PHP string (technically a sequence of
+bytes):
+
+```php
+$bytes = wasm_read_bytes('my_program.wasm');
+$module = wasm_compile($bytes);
+$serialized_module = wasm_module_serialize($module);
+```
+
+This function returns a string.
+
+### Function `wasm_module_deserialize`
+
+Deserializes a module from a PHP string (technically a sequence of
+bytes):
+
+```php
+$bytes = wasm_read_bytes('my_program.wasm');
+$module = wasm_compile($bytes);
+$serialized_module = wasm_module_serialize($module);
+unset($module);
+
+$module = wasm_module_deserialize($module);
+$instance = wasm_module_new_instance($module);
+// life continues.
+```
+
+This function returns a resource of type `wasm_module`.
+
 ### Function `wasm_module_new_instance`
 
 Instantiates a WebAssembly module:


### PR DESCRIPTION
Address #18. Blocked https://github.com/wasmerio/wasmer/pull/271.

This patch implements 2 new functions:

  * `wasm_module_serialize`, to serialize a module into a PHP string, i.e. a sequence of bytes,
  * `wasm_module_deserialize`, to deserialize a serialized module into a `wasm_module` resource.

Documentation and tests have been updated accordingly.