### PR TITLE
fix(extension) Use `ZEND_RETURN_VALUE` instead of custom macros

### DIFF
--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -25,12 +25,6 @@
 #include "php_wasm.h"
 #include "wasmer.hh"
 
-// Constant to represent a (returned) value passed by copy.
-#define BY_COPY 0
-
-// Constant to represent a (returned) value passed by reference.
-#define BY_REFERENCE 0
-
 // Constant to represent a not nullable (return) type.
 #define NOT_NULLABLE 0
 
@@ -84,7 +78,7 @@ static void wasm_bytes_destructor(zend_resource *resource)
 /**
  * Declare the parameter information for the `wasm_read_bytes` function.
  */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_read_bytes, BY_COPY, ARITY(1), IS_RESOURCE, NULLABLE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_read_bytes, ZEND_RETURN_VALUE, ARITY(1), IS_RESOURCE, NULLABLE)
     ZEND_ARG_TYPE_INFO(0, file_path, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -141,7 +135,7 @@ PHP_FUNCTION(wasm_read_bytes)
  * Declare the parameter information for the `wasm_validate`
  * function.
  */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_validate, BY_COPY, ARITY(1), _IS_BOOL, NOT_NULLABLE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_validate, ZEND_RETURN_VALUE, ARITY(1), _IS_BOOL, NOT_NULLABLE)
     ZEND_ARG_TYPE_INFO(0, wasm_bytes, IS_RESOURCE, 0)
 ZEND_END_ARG_INFO()
 
@@ -203,7 +197,7 @@ static void wasm_module_destructor(zend_resource *resource)
  * Declare the parameter information for the `wasm_compile`
  * function.
  */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_compile, BY_COPY, ARITY(1), IS_RESOURCE, NULLABLE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_compile, ZEND_RETURN_VALUE, ARITY(1), IS_RESOURCE, NULLABLE)
     ZEND_ARG_TYPE_INFO(0, wasm_bytes, IS_RESOURCE, 0)
 ZEND_END_ARG_INFO()
 
@@ -256,7 +250,7 @@ PHP_FUNCTION(wasm_compile)
  * Declare the parameter information for the `wasm_module_serialize`
  * function.
  */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_module_serialize, BY_COPY, ARITY(1), IS_STRING, NULLABLE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_module_serialize, ZEND_RETURN_VALUE, ARITY(1), IS_STRING, NULLABLE)
     ZEND_ARG_TYPE_INFO(0, wasm_module, IS_RESOURCE, 0)
 ZEND_END_ARG_INFO()
 
@@ -304,7 +298,7 @@ PHP_FUNCTION(wasm_module_serialize)
  * Declare the parameter information for the `wasm_module_deserialize`
  * function.
  */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_module_deserialize, BY_COPY, ARITY(1), IS_RESOURCE, NULLABLE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_module_deserialize, ZEND_RETURN_VALUE, ARITY(1), IS_RESOURCE, NULLABLE)
     ZEND_ARG_TYPE_INFO(0, wasm_serialized_module, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
@@ -378,7 +372,7 @@ static void wasm_instance_destructor(zend_resource *resource)
  * Declare the parameter information for the
  * `wasm_module_new_instance` function.
  */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_module_new_instance, BY_COPY, ARITY(1), IS_RESOURCE, NULLABLE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_module_new_instance, ZEND_RETURN_VALUE, ARITY(1), IS_RESOURCE, NULLABLE)
     ZEND_ARG_TYPE_INFO(0, wasm_module, IS_RESOURCE, 0)
 ZEND_END_ARG_INFO()
 
@@ -442,7 +436,7 @@ PHP_FUNCTION(wasm_module_new_instance)
  * Declare the parameter information for the `wasm_new_instance`
  * function.
  */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_new_instance, BY_COPY, ARITY(1), IS_RESOURCE, NULLABLE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_new_instance, ZEND_RETURN_VALUE, ARITY(1), IS_RESOURCE, NULLABLE)
     ZEND_ARG_TYPE_INFO(0, wasm_bytes, IS_RESOURCE, 0)
 ZEND_END_ARG_INFO()
 
@@ -502,7 +496,7 @@ PHP_FUNCTION(wasm_new_instance)
  * Declare the parameter information for the
  * `wasm_get_function_signature` function.
  */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_get_function_signature, BY_COPY, ARITY(2), IS_ARRAY, NULLABLE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_get_function_signature, ZEND_RETURN_VALUE, ARITY(2), IS_ARRAY, NULLABLE)
     ZEND_ARG_TYPE_INFO(0, wasm_instance, IS_RESOURCE, 0)
     ZEND_ARG_TYPE_INFO(0, function_name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -668,7 +662,7 @@ static void wasm_value_destructor(zend_resource *resource)
 /**
  * Declare the parameter information for the `wasm_value` function.
  */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_value, BY_COPY, ARITY(2), IS_RESOURCE, NULLABLE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_value, ZEND_RETURN_VALUE, ARITY(2), IS_RESOURCE, NULLABLE)
     ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
     ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
@@ -733,7 +727,7 @@ PHP_FUNCTION(wasm_value)
  * Declare the parameter information for the `wasm_invoke_function`
  * function.
  */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_invoke_function, BY_COPY, ARITY(3), _IS_NUMBER, NULLABLE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_invoke_function, ZEND_RETURN_VALUE, ARITY(3), _IS_NUMBER, NULLABLE)
     ZEND_ARG_TYPE_INFO(0, wasm_instance, IS_RESOURCE, 0)
     ZEND_ARG_TYPE_INFO(0, function_name, IS_STRING, 0)
     ZEND_ARG_ARRAY_INFO(0, inputs, 0)
@@ -836,7 +830,7 @@ PHP_FUNCTION(wasm_invoke_function)
  * Declare the parameter information for the `wasm_get_last_error`
  * function.
  */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_get_last_error, BY_COPY, ARITY(0), IS_STRING, NULLABLE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_get_last_error, ZEND_RETURN_VALUE, ARITY(0), IS_STRING, NULLABLE)
 ZEND_END_ARG_INFO()
 
 /**


### PR DESCRIPTION
In https://twitter.com/SaraMG/status/1108366411297181698, @sgolemon
teached me about `ZEND_RETURN_VALUE`. It replaces `BY_COPY`. Same for
`ZEND_RETURN_REFERENCE` that replaces `BY_REFERENCE`.