### PR TITLE
feat(extension) Persistent modules

### DIFF
--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -135,7 +135,7 @@ static void wasm_bytes_destructor(zend_resource *resource)
  * Declare the parameter information for the `wasm_fetch_bytes` function.
  */
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_fetch_bytes, ZEND_RETURN_VALUE, ARITY(1), IS_RESOURCE, NOT_NULLABLE)
-    ZEND_ARG_TYPE_INFO(0, file_path, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, file_path, IS_STRING, NOT_NULLABLE)
 ZEND_END_ARG_INFO()
 
 /**
@@ -170,7 +170,7 @@ PHP_FUNCTION(wasm_fetch_bytes)
  * function.
  */
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_validate, ZEND_RETURN_VALUE, ARITY(1), _IS_BOOL, NOT_NULLABLE)
-    ZEND_ARG_TYPE_INFO(0, wasm_bytes, IS_RESOURCE, 0)
+    ZEND_ARG_TYPE_INFO(0, wasm_bytes, IS_RESOURCE, NOT_NULLABLE)
 ZEND_END_ARG_INFO()
 
 /**
@@ -305,7 +305,7 @@ PHP_FUNCTION(wasm_compile)
  * function.
  */
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_module_serialize, ZEND_RETURN_VALUE, ARITY(1), IS_STRING, NULLABLE)
-    ZEND_ARG_TYPE_INFO(0, wasm_module, IS_RESOURCE, 0)
+    ZEND_ARG_TYPE_INFO(0, wasm_module, IS_RESOURCE, NOT_NULLABLE)
 ZEND_END_ARG_INFO()
 
 /**
@@ -353,7 +353,7 @@ PHP_FUNCTION(wasm_module_serialize)
  * function.
  */
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_module_deserialize, ZEND_RETURN_VALUE, ARITY(1), IS_RESOURCE, NULLABLE)
-    ZEND_ARG_TYPE_INFO(0, wasm_serialized_module, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, wasm_serialized_module, IS_STRING, NOT_NULLABLE)
 ZEND_END_ARG_INFO()
 
 /**
@@ -427,7 +427,7 @@ static void wasm_instance_destructor(zend_resource *resource)
  * `wasm_module_new_instance` function.
  */
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_module_new_instance, ZEND_RETURN_VALUE, ARITY(1), IS_RESOURCE, NULLABLE)
-    ZEND_ARG_TYPE_INFO(0, wasm_module, IS_RESOURCE, 0)
+    ZEND_ARG_TYPE_INFO(0, wasm_module, IS_RESOURCE, NOT_NULLABLE)
 ZEND_END_ARG_INFO()
 
 /**
@@ -491,7 +491,7 @@ PHP_FUNCTION(wasm_module_new_instance)
  * function.
  */
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_new_instance, ZEND_RETURN_VALUE, ARITY(1), IS_RESOURCE, NULLABLE)
-    ZEND_ARG_TYPE_INFO(0, wasm_bytes, IS_RESOURCE, 0)
+    ZEND_ARG_TYPE_INFO(0, wasm_bytes, IS_RESOURCE, NOT_NULLABLE)
 ZEND_END_ARG_INFO()
 
 /**
@@ -555,8 +555,8 @@ PHP_FUNCTION(wasm_new_instance)
  * `wasm_get_function_signature` function.
  */
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_get_function_signature, ZEND_RETURN_VALUE, ARITY(2), IS_ARRAY, NULLABLE)
-    ZEND_ARG_TYPE_INFO(0, wasm_instance, IS_RESOURCE, 0)
-    ZEND_ARG_TYPE_INFO(0, function_name, IS_STRING, 0)
+    ZEND_ARG_TYPE_INFO(0, wasm_instance, IS_RESOURCE, NOT_NULLABLE)
+    ZEND_ARG_TYPE_INFO(0, function_name, IS_STRING, NOT_NULLABLE)
 ZEND_END_ARG_INFO()
 
 /**
@@ -721,7 +721,7 @@ static void wasm_value_destructor(zend_resource *resource)
  * Declare the parameter information for the `wasm_value` function.
  */
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_value, ZEND_RETURN_VALUE, ARITY(2), IS_RESOURCE, NULLABLE)
-    ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+    ZEND_ARG_TYPE_INFO(0, type, IS_LONG, NOT_NULLABLE)
     ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()
 
@@ -786,9 +786,9 @@ PHP_FUNCTION(wasm_value)
  * function.
  */
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_invoke_function, ZEND_RETURN_VALUE, ARITY(3), _IS_NUMBER, NULLABLE)
-    ZEND_ARG_TYPE_INFO(0, wasm_instance, IS_RESOURCE, 0)
-    ZEND_ARG_TYPE_INFO(0, function_name, IS_STRING, 0)
-    ZEND_ARG_ARRAY_INFO(0, inputs, 0)
+    ZEND_ARG_TYPE_INFO(0, wasm_instance, IS_RESOURCE, NOT_NULLABLE)
+    ZEND_ARG_TYPE_INFO(0, function_name, IS_STRING, NOT_NULLABLE)
+    ZEND_ARG_ARRAY_INFO(0, inputs, NOT_NULLABLE)
 ZEND_END_ARG_INFO()
 
 /**

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -381,7 +381,7 @@ static void php_wasm_module_clean_up_persistent_resources()
  * Declare the parameter information for the `wasm_module_clean_up_persistent_resources`
  * function.
  */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_module_clean_up_persistence_resources, ZEND_RETURN_VALUE, ARITY(0), IS_VOID, NOT_NULLABLE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_module_clean_up_persistent_resources, ZEND_RETURN_VALUE, ARITY(0), IS_VOID, NOT_NULLABLE)
 ZEND_END_ARG_INFO()
 
 /**
@@ -1133,7 +1133,7 @@ static const zend_function_entry wasm_functions[] = {
     PHP_FE(wasm_fetch_bytes,							arginfo_wasm_fetch_bytes)
     PHP_FE(wasm_validate,								arginfo_wasm_validate)
     PHP_FE(wasm_compile,								arginfo_wasm_compile)
-    PHP_FE(wasm_module_clean_up_persistent_resources,	arginfo_wasm_compile)
+    PHP_FE(wasm_module_clean_up_persistent_resources,	arginfo_wasm_module_clean_up_persistent_resources)
     PHP_FE(wasm_module_new_instance,					arginfo_wasm_module_new_instance)
     PHP_FE(wasm_module_serialize,						arginfo_wasm_module_serialize)
     PHP_FE(wasm_module_deserialize,						arginfo_wasm_module_deserialize)

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -194,6 +194,10 @@ PHP_FUNCTION(wasm_validate)
     // Extract the bytes from the resource.
     wasmer_byte_array *wasm_byte_array = wasm_bytes_from_resource(Z_RES_P(wasm_bytes_resource));
 
+    if (NULL == wasm_byte_array) {
+        RETURN_FALSE;
+    }
+
     // Check whether the bytes are valid or not.
     bool is_valid = wasmer_validate(wasm_byte_array->bytes, wasm_byte_array->bytes_len);
 
@@ -261,6 +265,10 @@ PHP_FUNCTION(wasm_compile)
     if (resource == NULL) {
         // Extract the bytes from the resource.
         wasmer_byte_array *wasm_byte_array = wasm_bytes_from_resource(Z_RES_P(wasm_bytes_resource));
+
+        if (NULL == wasm_byte_array) {
+            RETURN_NULL();
+        }
 
         // Create a new Wasm module.
         wasmer_module_t *wasm_module = NULL;
@@ -510,6 +518,10 @@ PHP_FUNCTION(wasm_new_instance)
 
     // Extract the bytes from the resource.
     wasmer_byte_array *wasm_byte_array = wasm_bytes_from_resource(Z_RES_P(wasm_bytes_resource));
+
+    if (NULL == wasm_byte_array) {
+        RETURN_NULL();
+    }
 
     // Create a new Wasm instance.
     wasmer_instance_t *wasm_instance = NULL;

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -289,10 +289,12 @@ PHP_FUNCTION(wasm_compile)
         Z_PARAM_STR_EX(wasm_module_unique_identifier, NULLABLE, 0);
     ZEND_PARSE_PARAMETERS_END();
 
-    // The Wasm module resource will be persistent if there is a unique identifier.
+    zend_string *resource_key = NULL;
     bool persistent_wasm_module = false;
 
+    // The Wasm module resource will be persistent if there is a unique identifier.
     if (wasm_module_unique_identifier != NULL) {
+        resource_key = zend_string_copy(wasm_module_unique_identifier);
         persistent_wasm_module = true;
     }
 
@@ -300,7 +302,7 @@ PHP_FUNCTION(wasm_compile)
 
     // Wasm module persistent resource look up.
     if (persistent_wasm_module) {
-        resource = (zend_resource *) zend_hash_find_ptr(&EG(persistent_list), wasm_module_unique_identifier);
+        resource = (zend_resource *) zend_hash_find_ptr(&EG(persistent_list), resource_key);
     }
 
     // Wasm module persistent resource is disabled, or it is not
@@ -333,7 +335,7 @@ PHP_FUNCTION(wasm_compile)
         // Store the module in a persistent resource.
         if (persistent_wasm_module) {
             resource = zend_register_persistent_resource_ex(
-                wasm_module_unique_identifier,
+                resource_key,
                 (void *) wasm_module,
                 wasm_module_resource_number
             );

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -132,23 +132,23 @@ static void wasm_bytes_destructor(zend_resource *resource)
 }
 
 /**
- * Declare the parameter information for the `wasm_read_bytes` function.
+ * Declare the parameter information for the `wasm_fetch_bytes` function.
  */
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_read_bytes, ZEND_RETURN_VALUE, ARITY(1), IS_RESOURCE, NULLABLE)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasm_fetch_bytes, ZEND_RETURN_VALUE, ARITY(1), IS_RESOURCE, NOT_NULLABLE)
     ZEND_ARG_TYPE_INFO(0, file_path, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 /**
- * Declare the `wasm_read_bytes` function.
+ * Declare the `wasm_fetch_bytes` function.
  *
  * # Usage
  *
  * ```php
- * $bytes = wasm_read_bytes('my_program.wasm');
+ * $bytes = wasm_fetch_bytes('my_program.wasm');
  * // `$bytes` is of type `resource of type (wasm_bytes)`.
  * ```
  */
-PHP_FUNCTION(wasm_read_bytes)
+PHP_FUNCTION(wasm_fetch_bytes)
 {
     char *file_path;
     size_t file_path_length;
@@ -179,7 +179,7 @@ ZEND_END_ARG_INFO()
  * # Usage
  *
  * ```php
- $ $bytes = wasm_read_bytes('my_program.wasm');
+ $ $bytes = wasm_fetch_bytes('my_program.wasm');
  * $valid = wasm_validate($bytes);
  * ```
  */
@@ -245,7 +245,7 @@ ZEND_END_ARG_INFO()
  * # Usage
  *
  * ```php
- * $bytes = wasm_read_bytes('my_program.wasm');
+ * $bytes = wasm_fetch_bytes('my_program.wasm');
  * $module = wasm_compile($bytes);
  * // `$module` is of type `resource of type (wasm_module)`.
  * ```
@@ -314,7 +314,7 @@ ZEND_END_ARG_INFO()
  * # Usage
  *
  * ```php
- * $bytes = wasm_read_bytes('my_program.wasm');
+ * $bytes = wasm_fetch_bytes('my_program.wasm');
  * $module = wasm_compile($bytes);
  * $serialized_module = wasm_module_serialize($module);
  * // `$serialized_module` is of type `string`.
@@ -362,7 +362,7 @@ ZEND_END_ARG_INFO()
  * # Usage
  *
  * ```php
- * $bytes = wasm_read_bytes('my_program.wasm');
+ * $bytes = wasm_fetch_bytes('my_program.wasm');
  * $module = wasm_compile($bytes);
  * $serialized_module = wasm_module_serialize($module);
  * $module = wasm_module_deserialize($serialized_module);
@@ -436,7 +436,7 @@ ZEND_END_ARG_INFO()
  * # Usage
  *
  * ```php
- * $bytes = wasm_read_bytes('my_program.wasm');
+ * $bytes = wasm_fetch_bytes('my_program.wasm');
  * $module = wasm_compile($bytes);
  * $instance = wasm_module_new_instance($module);
  * // `$instance` is of type `resource of type (wasm_instance)`.
@@ -445,7 +445,7 @@ ZEND_END_ARG_INFO()
  * It is similar to running:
  *
  * ```php
- * $bytes = wasm_read_bytes('my_program.wasm');
+ * $bytes = wasm_fetch_bytes('my_program.wasm');
  * $instance = wasm_new_instance($bytes);
  * ```
  */
@@ -500,7 +500,7 @@ ZEND_END_ARG_INFO()
  * # Usage
  *
  * ```php
- * $bytes = wasm_read_bytes('my_program.wasm');
+ * $bytes = wasm_fetch_bytes('my_program.wasm');
  * $instance = wasm_new_instance($bytes);
  * // `$instance` is of type `resource of type (wasm_instance)`.
  * ```
@@ -565,7 +565,7 @@ ZEND_END_ARG_INFO()
  * # Usage
  *
  * ```php
- * $bytes = wasm_read_bytes('my_program.wasm');
+ * $bytes = wasm_fetch_bytes('my_program.wasm');
  * $instance = wasm_new_instance($bytes);
  * $signature = wasm_get_function_signature($instance, 'function_name');
  * // `$signature` is an array of `WASM_TYPE_*` constants. The first
@@ -797,7 +797,7 @@ ZEND_END_ARG_INFO()
  * # Usage
  *
  * ```php
- * $bytes = wasm_read_bytes('my_program.wasm');
+ * $bytes = wasm_fetch_bytes('my_program.wasm');
  * $instance = wasm_new_instance($bytes);
  *
  * // sum(1, 2)
@@ -1009,7 +1009,7 @@ PHP_MSHUTDOWN_FUNCTION(wasm)
 
 // Export the functions with their information.
 static const zend_function_entry wasm_functions[] = {
-    PHP_FE(wasm_read_bytes,				arginfo_wasm_read_bytes)
+    PHP_FE(wasm_fetch_bytes,			arginfo_wasm_fetch_bytes)
     PHP_FE(wasm_validate,				arginfo_wasm_validate)
     PHP_FE(wasm_compile,				arginfo_wasm_compile)
     PHP_FE(wasm_module_new_instance,	arginfo_wasm_module_new_instance)

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -151,7 +151,7 @@ ZEND_END_ARG_INFO()
  * Important note: The bytes are fetched, not read, when the function
  * is called. It means that the bytes are lazily read when other
  * functions need it, like `wasm_validate`, `wasm_compile` and
- * `wasm_instance`.
+ * `wasm_new_instance`.
  */
 PHP_FUNCTION(wasm_fetch_bytes)
 {

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -147,6 +147,11 @@ ZEND_END_ARG_INFO()
  * $bytes = wasm_fetch_bytes('my_program.wasm');
  * // `$bytes` is of type `resource of type (wasm_bytes)`.
  * ```
+ *
+ * Important note: The bytes are fetched, not read, when the function
+ * is called. It means that the bytes are lazily read when other
+ * functions need it, like `wasm_validate`, `wasm_compile` and
+ * `wasm_instance`.
  */
 PHP_FUNCTION(wasm_fetch_bytes)
 {
@@ -245,11 +250,28 @@ ZEND_END_ARG_INFO()
  *
  * # Usage
  *
+ * Classical usage:
+ *
  * ```php
  * $bytes = wasm_fetch_bytes('my_program.wasm');
  * $module = wasm_compile($bytes);
  * // `$module` is of type `resource of type (wasm_module)`.
  * ```
+ *
+ * If one wants to avoid to recompile the module each time, it is
+ * possible to compute a persistent resource by passing a module
+ * unique identifier string, e.g.:
+ *
+ * ```php
+ * $bytes = wasm_fetch_bytes('my_program.wasm');
+ * $module = wasm_compile($bytes, 'foo');
+ * // `$module` is of type `resource of type (wasm_module)`, and persistent.
+ * ```
+ *
+ * In the case above, further execution will **not** fetch the bytes
+ * nor compile the module. Indeed, bytes are not fetched because they
+ * are lazily fetch on-demand, and the module will not be re-compiled
+ * because the resource is persistent.
  */
 PHP_FUNCTION(wasm_compile)
 {

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -233,6 +233,11 @@ wasmer_module_t *wasm_module_from_resource(zend_resource *wasm_module_resource)
 static void wasm_module_destructor(zend_resource *resource)
 {
     wasmer_module_t *wasm_module = wasm_module_from_resource(resource);
+
+    if (wasm_module == NULL) {
+        return;
+    }
+
     wasmer_module_destroy(wasm_module);
 }
 
@@ -379,6 +384,10 @@ PHP_FUNCTION(wasm_module_serialize)
     // Extract the module from the resource.
     wasmer_module_t *wasm_module = wasm_module_from_resource(Z_RES_P(wasm_module_resource));
 
+    if (wasm_module == NULL) {
+        RETURN_NULL();
+    }
+
     // Let's serialize the module.
     wasmer_serialized_module_t *wasm_serialized_module = NULL;
 
@@ -467,6 +476,11 @@ wasmer_instance_t *wasm_instance_from_resource(zend_resource *wasm_instance_reso
 static void wasm_instance_destructor(zend_resource *resource)
 {
     wasmer_instance_t *wasm_instance = wasm_instance_from_resource(resource);
+
+    if (wasm_instance == NULL) {
+        return;
+    }
+
     wasmer_instance_destroy(wasm_instance);
 }
 
@@ -507,6 +521,10 @@ PHP_FUNCTION(wasm_module_new_instance)
 
     // Extract the module from the resource.
     wasmer_module_t *wasm_module = wasm_module_from_resource(Z_RES_P(wasm_module_resource));
+
+    if (wasm_module == NULL) {
+        RETURN_NULL();
+    }
 
     // Create a new Wasm instance.
     wasmer_instance_t *wasm_instance = NULL;
@@ -633,6 +651,10 @@ PHP_FUNCTION(wasm_get_function_signature)
 
     // Extract the Wasm instance from the resource.
     wasmer_instance_t *wasm_instance = wasm_instance_from_resource(Z_RES_P(wasm_instance_resource));
+
+    if (NULL == wasm_instance) {
+        RETURN_NULL();
+    }
 
     // Read all the export definitions (of all kinds).
     wasmer_exports_t *wasm_exports = NULL;
@@ -762,6 +784,11 @@ wasmer_value_t *wasm_value_from_resource(zend_resource *wasm_value_resource)
 static void wasm_value_destructor(zend_resource *resource)
 {
     wasmer_value_t *wasm_value = wasm_value_from_resource(resource);
+
+    if (wasm_value == NULL) {
+        return;
+    }
+
     free(wasm_value);
 }
 
@@ -874,6 +901,10 @@ PHP_FUNCTION(wasm_invoke_function)
 
     // Extract the Wasm instance from the resource.
     wasmer_instance_t *wasm_instance = wasm_instance_from_resource(Z_RES_P(wasm_instance_resource));
+
+    if (NULL == wasm_instance) {
+        RETURN_NULL();
+    }
 
     // Read the number of inputs.
     size_t function_input_length = zend_hash_num_elements(inputs);

--- a/lib/Instance.php
+++ b/lib/Instance.php
@@ -52,16 +52,11 @@ class Instance
         }
 
         $wasmBytes = wasm_fetch_bytes($filePath);
-
-        if (false === wasm_validate($wasmBytes)) {
-            throw new RuntimeException("Bytes in `$filePath` are invalid.");
-        }
-
         $this->wasmInstance = wasm_new_instance($wasmBytes);
 
         if (null === $this->wasmInstance) {
             throw new RuntimeException(
-                "An error happened while compiling or instanciating the module `$filePath`:\n    " .
+                "An error happened while compiling or instantiating the module `$filePath`:\n    " .
                 str_replace("\n", "\n    ", wasm_get_last_error())
             );
         }

--- a/lib/Instance.php
+++ b/lib/Instance.php
@@ -51,11 +51,7 @@ class Instance
             throw new RuntimeException("File `$filePath` is not readable.");
         }
 
-        $wasmBytes = wasm_read_bytes($filePath);
-
-        if (null === $wasmBytes) {
-            throw new RuntimeException("An error happened while reading the module `$filePath`.");
-        }
+        $wasmBytes = wasm_fetch_bytes($filePath);
 
         if (false === wasm_validate($wasmBytes)) {
             throw new RuntimeException("Bytes in `$filePath` are invalid.");

--- a/lib/Module.php
+++ b/lib/Module.php
@@ -90,14 +90,6 @@ class Module implements Serializable
 
         if (self::PERSISTENT === $persistence) {
             $wasmModuleUniqueIdentifier = $this->getUniqueIdentifier($filePath);
-        } else {
-            // Validating WebAssembly bytes forces the `wasm_bytes` resource to
-            // be read. In the case of a persistent module, we don't want to
-            // read the bytes. That's why `wasm_validate` is called only when
-            // the module is not persistent.
-            if (false === wasm_validate($wasmBytes)) {
-                throw new RuntimeException("Bytes in `$filePath` are invalid.");
-            }
         }
 
         $this->wasmModule = wasm_compile($wasmBytes, $wasmModuleUniqueIdentifier);

--- a/lib/Module.php
+++ b/lib/Module.php
@@ -50,7 +50,7 @@ class Module implements Serializable
             throw new RuntimeException("File `$filePath` is not readable.");
         }
 
-        $wasmBytes = wasm_read_bytes($filePath);
+        $wasmBytes = wasm_fetch_bytes($filePath);
 
         if (null === $wasmBytes) {
             throw new RuntimeException("An error happened while reading the module `$filePath`.");

--- a/lib/README.md
+++ b/lib/README.md
@@ -69,22 +69,22 @@ backend](https://github.com/wasmerio/wasmer/tree/master/lib#backends)
 This section presents the raw API provided by the `php-ext-wasm`
 extension. The entire `Wasm` library is based on this API.
 
-### Function `wasm_read_bytes`
+### Function `wasm_fetch_bytes`
 
 Reads bytes from a WebAssembly file:
 
 ```php
-$bytes = wasm_read_bytes('my_program.wasm');
+$bytes = wasm_fetch_bytes('my_program.wasm');
 ```
 
 This function returns a resource of type `wasm_bytes`.
 
 ### Function `wasm_validate`
 
-Validates bytes from the `wasm_read_bytes` function:
+Validates bytes from the `wasm_fetch_bytes` function:
 
 ```php
-$bytes = wasm_read_bytes('my_program.wasm');
+$bytes = wasm_fetch_bytes('my_program.wasm');
 
 if (false === wasm_validate($bytes)) {
     echo 'The program seems corrupted.';
@@ -99,7 +99,7 @@ otherwise.
 Compiles bytes into a WebAssembly module.
 
 ```php
-$bytes = wasm_read_bytes('my_program.wasm');
+$bytes = wasm_fetch_bytes('my_program.wasm');
 $module = wasm_compile($bytes);
 ```
 
@@ -111,7 +111,7 @@ Serializes a module into a PHP string (technically a sequence of
 bytes):
 
 ```php
-$bytes = wasm_read_bytes('my_program.wasm');
+$bytes = wasm_fetch_bytes('my_program.wasm');
 $module = wasm_compile($bytes);
 $serialized_module = wasm_module_serialize($module);
 ```
@@ -124,7 +124,7 @@ Deserializes a module from a PHP string (technically a sequence of
 bytes):
 
 ```php
-$bytes = wasm_read_bytes('my_program.wasm');
+$bytes = wasm_fetch_bytes('my_program.wasm');
 $module = wasm_compile($bytes);
 $serialized_module = wasm_module_serialize($module);
 unset($module);
@@ -141,7 +141,7 @@ This function returns a resource of type `wasm_module`.
 Instantiates a WebAssembly module:
 
 ```php
-$bytes = wasm_read_bytes('my_program.wasm');
+$bytes = wasm_fetch_bytes('my_program.wasm');
 $module = wasm_compile($bytes);
 $instance = wasm_module_new_instance($module);
 ```
@@ -153,7 +153,7 @@ This function returns a resource of type `wasm_instance`.
 Compiles and instantiates WebAssembly bytes:
 
 ```php
-$bytes = wasm_read_bytes('my_program.wasm');
+$bytes = wasm_fetch_bytes('my_program.wasm');
 $instance = wasm_new_instance($bytes);
 ```
 
@@ -167,7 +167,7 @@ This function combines `wasm_compile` and
 Returns the signature of an exported function:
 
 ```php
-$bytes = wasm_read_bytes('my_program.wasm');
+$bytes = wasm_fetch_bytes('my_program.wasm');
 $instance = wasm_new_instance($bytes);
 $signature = wasm_get_function_signature($instance, 'function_name');
 ```
@@ -190,7 +190,7 @@ This function returns a resource of type `wasm_value`.
 Invokes a function that lives in the WebAssembly program.
 
 ```php
-$bytes = wasm_read_bytes('my_program.wasm');
+$bytes = wasm_fetch_bytes('my_program.wasm');
 $instance = wasm_new_instance($bytes);
 
 // sum(1, 2)
@@ -211,7 +211,7 @@ This function returns the result of the invoked function.
 Reads the last error if any:
 
 ```php
-$bytes = wasm_read_bytes('my_program.wasm');
+$bytes = wasm_fetch_bytes('my_program.wasm');
 $instance = wasm_new_instance($bytes);
 
 // sum(1) — one argument is missing!

--- a/lib/README.md
+++ b/lib/README.md
@@ -36,7 +36,7 @@ A WebAssembly file is only a sequence of bytes. In order to get a
 running WebAssembly program:
 
  1. These bytes must be compiled into a module,
- 2. The module must be instantiate.
+ 2. The module must be instantiated.
  
 The `Wasm\Module` represents a module. The `Wasm\Instance` represents
 an instance of a module.
@@ -57,12 +57,26 @@ $instance = new Wasm\Instance('my_program.wasm');
 $result = $instance->sum(1, 2);
 ```
 
-Why would one want to get a module? Because it's serializable, and
-thus can be stored in a cache. The bytes compilation to a module can
-be costly depending of the size of your WebAssembly program, and the
-[runtime
-backend](https://github.com/wasmerio/wasmer/tree/master/lib#backends)
-(LLVM, Cranelift etc.).
+Why would one want to get a module? For two reasons:
+
+  1. It can be persistent across multiple PHP requests, thus saving the cost of
+     the compilation,
+  2. It can be serialized, and thus can be stored in a cache, also to save the
+     cost of the compilation but with the cost of the deserialization.
+
+The bytes compilation to a module can be costly depending of the size of your
+WebAssembly program, and the [runtime
+backend](https://github.com/wasmerio/wasmer/tree/master/lib#backends) (LLVM,
+Cranelift etc.).
+
+See the `Wasm\Module` constructor to see how to get a persistent module; hint:
+
+```php
+$module = new Wasm\Module('my_program.wasm.', Wasm\Module::PERSISTENT);
+```
+
+See [the cache API](./wasm/cache/index.html) to learn about how to serialize a
+module.
 
 # The `php-ext-wasm` raw API
 

--- a/tests/units/Instance.php
+++ b/tests/units/Instance.php
@@ -40,7 +40,7 @@ class Instance extends Suite
                 }
             )
                 ->isInstanceOf(RuntimeException::class)
-                ->hasMessage("Bytes in `$filePath` are invalid.");
+                ->hasMessage("An error happened while compiling or instantiating the module `$filePath`:\n    ");
     }
 
     public function test_constructor_invalid_bytes()
@@ -53,7 +53,10 @@ class Instance extends Suite
                 }
             )
                 ->isInstanceOf(RuntimeException::class)
-                ->hasMessage("Bytes in `$filePath` are invalid.");
+                ->hasMessage(
+                    "An error happened while compiling or instantiating the module `$filePath`:\n" .
+                    "    error instantiating"
+                );
     }
 
     public function test_constructor_invalid_instantiation()
@@ -70,7 +73,7 @@ class Instance extends Suite
             )
                 ->isInstanceOf(RuntimeException::class)
                 ->hasMessage(
-                    "An error happened while compiling or instanciating the module `$filePath`:\n" .
+                    "An error happened while compiling or instantiating the module `$filePath`:\n" .
                     "    error instantiating"
                 );
     }

--- a/tests/units/Instance.php
+++ b/tests/units/Instance.php
@@ -16,7 +16,7 @@ class Instance extends Suite
     public function test_constructor_invalid_path()
     {
         $this
-            ->given($filePath = '/foo/bar')
+            ->given($filePath = __DIR__ . '/foo')
             ->exception(
                 function () use ($filePath) {
                     new SUT($filePath);
@@ -40,7 +40,7 @@ class Instance extends Suite
                 }
             )
                 ->isInstanceOf(RuntimeException::class)
-                ->hasMessage("An error happened while reading the module `$filePath`.");
+                ->hasMessage("Bytes in `$filePath` are invalid.");
     }
 
     public function test_constructor_invalid_bytes()

--- a/tests/units/Module.php
+++ b/tests/units/Module.php
@@ -50,7 +50,10 @@ class Module extends Suite
                 }
             )
                 ->isInstanceOf(RuntimeException::class)
-                ->hasMessage("Bytes in `$filePath` are invalid.");
+                ->hasMessage(
+                    "An error happened while compiling the module `$filePath`:\n" .
+                    "    "
+                );
     }
 
     public function test_constructor_invalid_bytes()
@@ -63,7 +66,10 @@ class Module extends Suite
                 }
             )
                 ->isInstanceOf(RuntimeException::class)
-                ->hasMessage("Bytes in `$filePath` are invalid.");
+                ->hasMessage(
+                    "An error happened while compiling the module `$filePath`:\n" .
+                    "    Validation error \"Invalid type\""
+                );
     }
 
     public function test_constructor_invalid_compilation()

--- a/tests/units/Module.php
+++ b/tests/units/Module.php
@@ -17,7 +17,7 @@ class Module extends Suite
     public function test_constructor_invalid_path()
     {
         $this
-            ->given($filePath = '/foo/bar')
+            ->given($filePath = __DIR__ . '/foo')
             ->exception(
                 function () use ($filePath) {
                     new SUT($filePath);
@@ -41,7 +41,7 @@ class Module extends Suite
                 }
             )
                 ->isInstanceOf(RuntimeException::class)
-                ->hasMessage("An error happened while reading the module `$filePath`.");
+                ->hasMessage("Bytes in `$filePath` are invalid.");
     }
 
     public function test_constructor_invalid_bytes()


### PR DESCRIPTION
Address #28.

A module can now be persistent. To enable it, pass a module unique identifier as a second argument to `wasm_compile` like this:

```php
$bytes = wasm_fetch_bytes('my_program.wasm');
$module = wasm_compile($bytes, 'unique_identifier_foo_bar');
```

Or with the library:

```php
$module = new Wasm\Module('my_program.wasm', Wasm\Module::PERSISTENT);
```

In this latter case, the module unique identifier is generated by the `Wasm\Module::getUniqueIdentifier` function, which by default computes the SHA3-512 of the real filepath.

This PR also renames `wasm_read_bytes` to `wasm_fetch_bytes`. Bytes are read lazily on-demand when the C function `wasm_bytes_from_resource` is called, i.e. when the PHP functions `wasm_validate`, `wasm_compile` and `wasm_new_instance` are called. Why? Because we don't want to read the bytes when the module has already been compiled and is persistent. So `wasm_compile` reads the bytes only when necessary.

Small benchmark with the `nbody.wasm` file:

  * Before `wasm_fetch_bytes` + `wasm_compile` 4.1968822ms
  * After `wasm_fetch_bytes` + `wasm_compile` with persistence 0.0050068ms

It brings a speedup of 838 times :tada:. Note that it's absurd to compare a read+compilation vs. nothing :-], but it shows that —effectively— nothing happens when a persistent resource is found.

This PR also introduces the `wasm_module_clean_up_persistent_resources` function but it must be used only when no PHP requests are running, else it's easy to corrupt concurrent executions since the destructor `wasm_module_destructor` function is called. This function is not used in the library.

By default, all `Wasm\Module` are volatile.