### PR TITLE
fix(extension) Register a persistent resource destructor.

### DIFF
--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -1073,7 +1073,7 @@ PHP_MINIT_FUNCTION(wasm)
     wasm_module_resource_name = "wasm_module";
     wasm_module_resource_number = zend_register_list_destructors_ex(
         wasm_module_destructor,
-        NULL,
+        wasm_module_destructor,
         wasm_module_resource_name,
         module_number
     );


### PR DESCRIPTION
Sequel of #33.

The `zend_register_list_destructors_ex` API expects one function
pointer for the resource destructor, and another function pointer for
the persistent resource destructor. I missed that details, and it
explains why the destructor was never called for a persistent
resource. Now it works! No more memory leaks.

cc @nikic in case you want to know the end of the story :-).