### PR TITLE
feat: Implement the `WasmArrayBuffer` class

### DIFF
--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -1270,6 +1270,7 @@ PHP_MINIT_FUNCTION(wasm)
     wasm_array_buffer_class_entry_handlers.offset = XtOffsetOf(wasm_array_buffer_object, instance);
     wasm_array_buffer_class_entry_handlers.dtor_obj = destroy_wasm_array_buffer_object;
     wasm_array_buffer_class_entry_handlers.free_obj = free_wasm_array_buffer_object;
+    wasm_array_buffer_class_entry_handlers.clone_obj = NULL;
 
     return SUCCESS;
 }

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -1397,7 +1397,7 @@ PHP_FUNCTION(WasmTypedArray___construct)
     }
 
     if (length < 0) {
-        zend_throw_exception_ex(zend_ce_exception, 2, "Level must be non-negative; given %lld.", length);
+        zend_throw_exception_ex(zend_ce_exception, 2, "Length must be non-negative; given %lld.", length);
 
         return;
     }
@@ -1541,7 +1541,7 @@ PHP_FUNCTION(WasmTypedArray_offset_get)
 
     wasm_typed_array_object *wasm_typed_array_object = WASM_TYPED_ARRAY_OBJECT_THIS();
 
-    if (offset < 0 || offset > wasm_typed_array_object->length) {
+    if (offset < 0 || offset >= wasm_typed_array_object->length) {
         zend_throw_exception_ex(
             zend_ce_exception,
             0,
@@ -1624,7 +1624,7 @@ PHP_FUNCTION(WasmTypedArray_offset_set)
 
     wasm_typed_array_object *wasm_typed_array_object = WASM_TYPED_ARRAY_OBJECT_THIS();
 
-    if (offset < 0 || offset > wasm_typed_array_object->length) {
+    if (offset < 0 || offset >= wasm_typed_array_object->length) {
         zend_throw_exception_ex(
             zend_ce_exception,
             0,
@@ -1707,7 +1707,7 @@ PHP_FUNCTION(WasmTypedArray_offset_exists)
 
     wasm_typed_array_object *wasm_typed_array_object = WASM_TYPED_ARRAY_OBJECT_THIS();
 
-    if (offset < 0 || offset > wasm_typed_array_object->length) {
+    if (offset < 0 || offset >= wasm_typed_array_object->length) {
         RETURN_FALSE;
     } else {
         RETURN_TRUE;
@@ -1745,7 +1745,7 @@ PHP_FUNCTION(WasmTypedArray_offset_unset)
 
     wasm_typed_array_object *wasm_typed_array_object = WASM_TYPED_ARRAY_OBJECT_THIS();
 
-    if (offset < 0 || offset > wasm_typed_array_object->length) {
+    if (offset < 0 || offset >= wasm_typed_array_object->length) {
         zend_throw_exception_ex(
             zend_ce_exception,
             0,

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -1173,7 +1173,7 @@ PHP_METHOD(WasmArrayBuffer, __construct)
     }
 
     wasm_array_buffer_object *wasm_array_buffer_object = WASM_ARRAY_BUFFER_OBJECT_THIS();
-    wasm_array_buffer_object->buffer = malloc(byte_length);
+    wasm_array_buffer_object->buffer = calloc(byte_length, byte_length);
     wasm_array_buffer_object->buffer_length = (size_t) byte_length;
 }
 

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -1747,7 +1747,7 @@ PHP_FUNCTION(WasmTypedArray_offset_exists)
  * Declare the parameter information for the
  * `WasmTypedArray::offsetUnset` method.
  */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_wasmtypedarray_offset_unset, 0, ZEND_RETURN_VALUE, ARITY(1))
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasmtypedarray_offset_unset, ZEND_RETURN_VALUE, ARITY(1), IS_VOID, NOT_NULLABLE)
     ZEND_ARG_INFO(0, offset)
 ZEND_END_ARG_INFO()
 

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -1690,7 +1690,7 @@ PHP_FUNCTION(WasmTypedArray_offset_set)
  * Declare the parameter information for the
  * `WasmTypedArray::offsetExists` method.
  */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_wasmtypedarray_offset_exists, 0, ZEND_RETURN_VALUE, ARITY(1))
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasmtypedarray_offset_exists, ZEND_RETURN_VALUE, ARITY(1), _IS_BOOL, NOT_NULLABLE)
     ZEND_ARG_INFO(0, offset)
 ZEND_END_ARG_INFO()
 

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -1624,7 +1624,7 @@ PHP_FUNCTION(WasmTypedArray_offset_get)
  * Declare the parameter information for the
  * `WasmTypedArray::offsetSet` method.
  */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_wasmtypedarray_offset_set, 0, ZEND_RETURN_VALUE, ARITY(2))
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wasmtypedarray_offset_set, ZEND_RETURN_VALUE, ARITY(2), IS_VOID, NOT_NULLABLE)
     ZEND_ARG_INFO(0, offset)
     ZEND_ARG_INFO(0, value)
 ZEND_END_ARG_INFO()

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -1165,7 +1165,7 @@ ZEND_END_ARG_INFO()
  * # Usage
  *
  * ```php
- $ $buffer = new WasmArrayBuffer();
+ $ $buffer = new WasmArrayBuffer(256);
  * ```
  */
 PHP_METHOD(WasmArrayBuffer, __construct)
@@ -1177,7 +1177,7 @@ PHP_METHOD(WasmArrayBuffer, __construct)
     ZEND_PARSE_PARAMETERS_END();
 
     if (byte_length <= 0) {
-        zend_throw_exception(zend_ce_exception, "Buffer length must be positive.", 0);
+        zend_throw_exception_ex(zend_ce_exception, 0, "Buffer length must be positive; given %lld.", byte_length);
 
         return;
     }

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -1867,19 +1867,20 @@ PHP_MINIT_FUNCTION(wasm)
     wasm_array_buffer_class_entry_handlers.clone_obj = NULL;
 
     // Declare the `WasmTypedArray` classes.
-#define DECLARE_WASM_TYPED_ARRAY(class_name, type) \
+#define DECLARE_WASM_TYPED_ARRAY(class_name, type, bytes_per_element) \
     INIT_CLASS_ENTRY(class_entry, #class_name, wasm_typed_array_methods); \
     wasm_typed_array_##type##_class_entry = zend_register_internal_class(&class_entry TSRMLS_CC); \
     wasm_typed_array_##type##_class_entry->create_object = create_wasm_typed_array_object; \
     wasm_typed_array_##type##_class_entry->ce_flags |= ZEND_ACC_FINAL; \
-    zend_class_implements(wasm_typed_array_##type##_class_entry TSRMLS_CC, 1, zend_ce_arrayaccess);
+    zend_class_implements(wasm_typed_array_##type##_class_entry TSRMLS_CC, 1, zend_ce_arrayaccess); \
+	zend_declare_class_constant_long(wasm_typed_array_##type##_class_entry, "BYTES_PER_ELEMENT", sizeof("BYTES_PER_ELEMENT")-1, (zend_long) bytes_per_element);
 
-    DECLARE_WASM_TYPED_ARRAY(WasmInt8Array, int8);
-    DECLARE_WASM_TYPED_ARRAY(WasmUint8Array, uint8);
-    DECLARE_WASM_TYPED_ARRAY(WasmInt16Array, int16);
-    DECLARE_WASM_TYPED_ARRAY(WasmUint16Array, uint16);
-    DECLARE_WASM_TYPED_ARRAY(WasmInt32Array, int32);
-    DECLARE_WASM_TYPED_ARRAY(WasmUint32Array, uint32);
+    DECLARE_WASM_TYPED_ARRAY(WasmInt8Array, int8, 1);
+    DECLARE_WASM_TYPED_ARRAY(WasmUint8Array, uint8, 1);
+    DECLARE_WASM_TYPED_ARRAY(WasmInt16Array, int16, 2);
+    DECLARE_WASM_TYPED_ARRAY(WasmUint16Array, uint16, 2);
+    DECLARE_WASM_TYPED_ARRAY(WasmInt32Array, int32, 4);
+    DECLARE_WASM_TYPED_ARRAY(WasmUint32Array, uint32, 4);
 
 #undef DECLARE_WASM_TYPED_ARRAY
 

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -1438,7 +1438,7 @@ PHP_FUNCTION(WasmTypedArray___construct)
         size_t maximum_length = (wasm_array_buffer_object->buffer_length - offset) / bytes_per_buffer_item;
 
         if (length == 0) {
-            length = maximum_length;
+            wasm_typed_array_object->length = maximum_length;
         } else if (length > maximum_length) {
             zend_throw_exception_ex(
                 zend_ce_exception,

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -1580,15 +1580,7 @@ PHP_FUNCTION(WasmTypedArray_offset_get)
             break;
 
         case wasm_typed_array_kind::UINT32:
-            {
-                uint32_t value = wasm_typed_array_object->view.as_uint32[offset];
-
-                if (value <= LONG_MAX) {
-                    RETURN_LONG(value);
-                } else {
-                    RETURN_DOUBLE(value);
-                }
-            }
+            RETURN_LONG(wasm_typed_array_object->view.as_uint32[offset]);
 
             break;
 

--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -70,7 +70,7 @@ public:
 
     ~wasm_lazy_byte_array_t()
     {
-        free((uint8_t *) byte_array->bytes);
+        efree((uint8_t *) byte_array->bytes);
     }
 
     wasmer_byte_array *get_bytes()
@@ -87,7 +87,7 @@ public:
             fseek(wasm_file, 0, SEEK_END);
 
             size_t wasm_file_length = ftell(wasm_file);
-            const uint8_t *wasm_bytes = (const uint8_t *) malloc(wasm_file_length);
+            const uint8_t *wasm_bytes = (const uint8_t *) emalloc(wasm_file_length);
             fseek(wasm_file, 0, SEEK_SET);
 
             fread((uint8_t *) wasm_bytes, 1, wasm_file_length, wasm_file);
@@ -96,7 +96,7 @@ public:
             fclose(wasm_file);
 
             // Store the bytes of the Wasm file into a `wasmer_byte_array` structure.
-            byte_array = (wasmer_byte_array *) malloc(sizeof(wasmer_byte_array));
+            byte_array = (wasmer_byte_array *) emalloc(sizeof(wasmer_byte_array));
             byte_array->bytes = wasm_bytes;
             byte_array->bytes_len = (uint32_t) wasm_file_length;
         }
@@ -847,7 +847,7 @@ static void wasm_value_destructor(zend_resource *resource)
         return;
     }
 
-    free(wasm_value);
+    efree(wasm_value);
 }
 
 /**
@@ -885,7 +885,7 @@ PHP_FUNCTION(wasm_value)
     // Convert the value to a `wasmer_value_tag`. It is expected to
     // receive a `WASM_TYPE_*` constant.
     wasmer_value_tag type = (wasmer_value_tag) (uint32_t) value_type;
-    wasmer_value_t *wasm_value = (wasmer_value_t *) malloc(sizeof(wasmer_value_t));
+    wasmer_value_t *wasm_value = (wasmer_value_t *) emalloc(sizeof(wasmer_value_t));
 
     // Convert the PHP value to a `wasm_value_t`.
     if (type == wasmer_value_tag::WASM_I32) {
@@ -903,7 +903,7 @@ PHP_FUNCTION(wasm_value)
     }
     // Invalid value type provided.
     else {
-        free(wasm_value);
+        efree(wasm_value);
 
         RETURN_NULL();
     }
@@ -968,7 +968,7 @@ PHP_FUNCTION(wasm_invoke_function)
     size_t function_input_length = zend_hash_num_elements(inputs);
 
     // Extract the input values from the `wasm_value` resources.
-    wasmer_value_t *function_inputs = (wasmer_value_t *) malloc(sizeof(wasmer_value_t) * function_input_length);
+    wasmer_value_t *function_inputs = (wasmer_value_t *) emalloc(sizeof(wasmer_value_t) * function_input_length);
 
     {
         zend_ulong key;
@@ -997,6 +997,8 @@ PHP_FUNCTION(wasm_invoke_function)
         function_outputs,
         function_output_length
     );
+
+    efree(function_inputs);
 
     // Failed to call the Wasm function.
     if (function_call_result != wasmer_result_t::WASMER_OK) {
@@ -1047,7 +1049,7 @@ PHP_FUNCTION(wasm_get_last_error)
         RETURN_NULL();
     }
 
-    char *error_message = (char *) malloc(error_message_length);
+    char *error_message = (char *) emalloc(error_message_length);
     wasmer_last_error_message(error_message, error_message_length);
 
     ZVAL_STRINGL(return_value, error_message, error_message_length - 1);

--- a/lib/README.md
+++ b/lib/README.md
@@ -339,7 +339,7 @@ class WasmUint8Array implements ArrayAccess
 
     /* For `ArrayAccess` */
     public function offsetGet($offset): int;
-    public function offsetSet($offset, $value);
+    public function offsetSet($offset, $value): void;
     public function offsetExists($offset): bool;
     public function offsetUnset($offset): void;
 }

--- a/lib/README.md
+++ b/lib/README.md
@@ -334,8 +334,8 @@ class WasmUint8Array implements ArrayAccess
     public const BYTES_PER_ELEMENT;
     
     public function __construct(WasmArrayBuffer $wasm_array_buffer, int $offset = 0, int $length = 0);
-    public function getOffset();
-    public function getLength();
+    public function getOffset(): int;
+    public function getLength(): int;
 
     /* For `ArrayAccess` */
     public function offsetGet($offset): int;

--- a/lib/README.md
+++ b/lib/README.md
@@ -341,7 +341,7 @@ class WasmUint8Array implements ArrayAccess
     public function offsetGet($offset): int;
     public function offsetSet($offset, $value);
     public function offsetExists($offset): bool;
-    public function offsetUnset($offset);
+    public function offsetUnset($offset): void;
 }
 ```
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -304,7 +304,7 @@ the memory of a WebAssembly instance.
 The class looks like this:
 
 ``` php
-class WasmArrayBuffer
+final class WasmArrayBuffer
 {
     public function __construct(int $byte_length);
     public function getByteLength(): int;
@@ -329,7 +329,7 @@ They all share the same implementation. Taking the example of
 `WasmUint8Array`, it looks like this:
 
 ```php
-class WasmUint8Array implements ArrayAccess
+final class WasmUint8Array implements ArrayAccess
 {
     public const BYTES_PER_ELEMENT;
     

--- a/tests/units/Extension/Classes.php
+++ b/tests/units/Extension/Classes.php
@@ -4,9 +4,11 @@ declare(strict_types = 1);
 
 namespace Wasm\Tests\Units\Extension;
 
+use Exception;
 use ReflectionClass;
 use ReflectionExtension;
 use ReflectionMethod;
+use WasmArrayBuffer;
 use Wasm\Tests\Suite;
 
 class Classes extends Suite
@@ -95,5 +97,53 @@ class Classes extends Suite
                     ->isTrue()
                 ->boolean($_result->isInternal())
                     ->isTrue();
+    }
+
+    public function test_wasm_array_buffer_constructor()
+    {
+        $this
+            ->when($result = new WasmArrayBuffer(42))
+            ->then
+                ->object($result)
+                    ->isInstanceOf(WasmArrayBuffer::class);
+    }
+
+    public function test_wasm_array_buffer_of_length_0()
+    {
+        $this
+            ->exception(
+                function() {
+                    new WasmArrayBuffer(0);
+                }
+            )
+                ->isInstanceOf(Exception::class)
+                ->hasMessage('Buffer length must be positive.')
+                ->hasCode(0);
+    }
+
+    public function test_wasm_array_buffer_with_a_negative_length()
+    {
+        $this
+            ->exception(
+                function() {
+                    new WasmArrayBuffer(-1);
+                }
+            )
+                ->isInstanceOf(Exception::class)
+                ->hasMessage('Buffer length must be positive.')
+                ->hasCode(0);
+    }
+
+    public function test_wasm_array_buffer_get_byte_length()
+    {
+        $this
+            ->given(
+                $byteLength = 42,
+                $wasmArrayBuffer = new WasmArrayBuffer($byteLength)
+            )
+            ->when($result = $wasmArrayBuffer->getByteLength())
+            ->then
+                ->integer($result)
+                    ->isEqualTo($byteLength);
     }
 }

--- a/tests/units/Extension/Classes.php
+++ b/tests/units/Extension/Classes.php
@@ -9,6 +9,7 @@ use Exception;
 use ReflectionClass;
 use ReflectionExtension;
 use ReflectionMethod;
+use StdClass;
 use WasmArrayBuffer;
 use WasmInt16Array;
 use WasmInt32Array;
@@ -22,7 +23,7 @@ class Classes extends Suite
 {
     public function getTestedClassName()
     {
-        return 'StdClass';
+        return StdClass::class;
     }
 
     public function getTestedClassNamespace()

--- a/tests/units/Extension/Classes.php
+++ b/tests/units/Extension/Classes.php
@@ -672,6 +672,31 @@ class Classes extends Suite
                     ->isEqualTo(0b01000000000100000000010000000001);
     }
 
+    public function test_wasm_typed_array_is_little_endian()
+    {
+        $this
+            ->given(
+                $wasmArrayBuffer = new WasmArrayBuffer(256),
+                $uint8 = new WasmUint8Array($wasmArrayBuffer),
+                $uint16 = new WasmUint16Array($wasmArrayBuffer),
+                $uint32 = new WasmUint32Array($wasmArrayBuffer)
+            )
+            ->when($uint32[0] = 0b00000000000000000000000000000001)
+            ->then
+                ->integer($uint8[0])
+                   ->isEqualTo(0b00000001)
+                ->integer($uint8[1])
+                   ->isEqualTo(0b00000000)
+                ->integer($uint8[2])
+                   ->isEqualTo(0b00000000)
+                ->integer($uint8[3])
+                   ->isEqualTo(0b00000000)
+                ->integer($uint16[0])
+                   ->isEqualTo(0b000000000000000001)
+                ->integer($uint32[0])
+                    ->isEqualTo(0b00000000000000000000000000000001);
+    }
+
     protected function wasm_typed_arrays()
     {
         yield [WasmInt8Array::class];

--- a/tests/units/Extension/Classes.php
+++ b/tests/units/Extension/Classes.php
@@ -4,11 +4,18 @@ declare(strict_types = 1);
 
 namespace Wasm\Tests\Units\Extension;
 
+use ArrayAccess;
 use Exception;
 use ReflectionClass;
 use ReflectionExtension;
 use ReflectionMethod;
 use WasmArrayBuffer;
+use WasmInt16Array;
+use WasmInt32Array;
+use WasmInt8Array;
+use WasmUint16Array;
+use WasmUint32Array;
+use WasmUint8Array;
 use Wasm\Tests\Suite;
 
 class Classes extends Suite
@@ -30,15 +37,26 @@ class Classes extends Suite
             ->when($result = $reflection->getClasses())
             ->then
                 ->array($result)
-                    ->hasSize(1)
+                    ->hasSize(7)
                     ->object['WasmArrayBuffer']->isInstanceOf(ReflectionClass::class)
+                    ->object['WasmInt8Array']->isInstanceOf(ReflectionClass::class)
+                    ->object['WasmUint8Array']->isInstanceOf(ReflectionClass::class)
+                    ->object['WasmInt16Array']->isInstanceOf(ReflectionClass::class)
+                    ->object['WasmUint16Array']->isInstanceOf(ReflectionClass::class)
+                    ->object['WasmInt32Array']->isInstanceOf(ReflectionClass::class)
+                    ->object['WasmUint32Array']->isInstanceOf(ReflectionClass::class);
+    }
 
-            ->when($_result = $result['WasmArrayBuffer'])
+    public function test_reflection_wasm_array_buffer()
+    {
+        $this
+            ->given($reflection = new ReflectionExtension('wasm'))
+            ->when($result = $reflection->getClasses()['WasmArrayBuffer'])
             ->then
-                ->array($_result->getConstants())
+                ->array($result->getConstants())
                     ->isEmpty()
 
-                ->let($methods = $_result->getMethods())
+                ->let($methods = $result->getMethods())
 
                 ->array($methods)
                     ->hasSize(2)
@@ -75,28 +93,234 @@ class Classes extends Suite
                 ->boolean($return_type->allowsNull())
                     ->isFalse()
 
-                ->boolean($_result->getParentClass())
+                ->boolean($result->getParentClass())
                     ->isFalse()
-                ->array($_result->getProperties())
+                ->array($result->getProperties())
                     ->isEmpty()
-                ->string($_result->getShortName())
+                ->string($result->getShortName())
                     ->isEqualTo('WasmArrayBuffer')
-                ->array($_result->getStaticProperties())
+                ->array($result->getStaticProperties())
                     ->isEmpty()
-                ->boolean($_result->inNamespace())
+                ->boolean($result->inNamespace())
                     ->isFalse()
-                ->boolean($_result->isAbstract())
+                ->boolean($result->isAbstract())
                     ->isFalse()
-                ->boolean($_result->isAnonymous())
+                ->boolean($result->isAnonymous())
                     ->isFalse()
-                ->boolean($_result->isCloneable())
+                ->boolean($result->isCloneable())
                     ->isFalse()
-                ->boolean($_result->isFinal())
+                ->boolean($result->isFinal())
                     ->isTrue()
-                ->boolean($_result->isInstantiable())
+                ->boolean($result->isInstantiable())
                     ->isTrue()
-                ->boolean($_result->isInternal())
+                ->boolean($result->isInternal())
                     ->isTrue();
+    }
+
+    /**
+     * @dataProvider wasm_typed_arrays
+     */
+    public function test_reflection_wasm_typed_array(string $wasmTypedArrayClassName)
+    {
+        $this
+            ->given($reflection = new ReflectionExtension('wasm'))
+            ->when($result = $reflection->getClasses()[$wasmTypedArrayClassName])
+            ->then
+                ->array($result->getConstants())
+                    ->isEmpty()
+
+                ->let($methods = $result->getMethods())
+
+                ->array($methods)
+                    ->hasSize(7)
+
+                ->string($methods[0]->getName())
+                    ->isEqualTo('__construct')
+                ->boolean($methods[0]->isPublic())
+                    ->isTrue()
+                ->integer($methods[0]->getNumberOfParameters())
+                    ->isEqualTo(3)
+                ->integer($methods[0]->getNumberOfRequiredParameters())
+                    ->isEqualTo(1)
+
+                ->let($parameters = $methods[0]->getParameters())
+
+                ->string($parameters[0]->getName())
+                    ->isEqualTo('wasm_array_buffer')
+                ->string($parameters[0]->getType() . '')
+                    ->isEqualTo(WasmArrayBuffer::class)
+                ->boolean($parameters[0]->getType()->allowsNull())
+                    ->isFalse()
+                ->boolean($parameters[0]->isOptional())
+                    ->isFalse()
+
+                ->string($parameters[1]->getName())
+                    ->isEqualTo('offset')
+                ->string($parameters[1]->getType() . '')
+                    ->isEqualTo('int')
+                ->boolean($parameters[1]->getType()->allowsNull())
+                    ->isFalse()
+                ->boolean($parameters[1]->isOptional())
+                    ->isTrue()
+
+                ->string($parameters[2]->getName())
+                    ->isEqualTo('length')
+                ->string($parameters[1]->getType() . '')
+                    ->isEqualTo('int')
+                ->boolean($parameters[2]->getType()->allowsNull())
+                    ->isFalse()
+                ->boolean($parameters[2]->isOptional())
+                    ->isTrue()
+
+                ->string($methods[1]->getName())
+                    ->isEqualTo('getOffset')
+                ->boolean($methods[1]->isPublic())
+                    ->isTrue()
+                ->integer($methods[1]->getNumberOfParameters())
+                    ->isEqualTo(0)
+                    ->isEqualTo($methods[1]->getNumberOfRequiredParameters())
+
+                ->let($return_type = $methods[1]->getReturnType())
+
+                ->string($return_type . '')
+                    ->isEqualTo('int')
+                ->boolean($return_type->allowsNull())
+                    ->isFalse()
+
+                ->string($methods[2]->getName())
+                    ->isEqualTo('getLength')
+                ->boolean($methods[2]->isPublic())
+                    ->isTrue()
+                ->integer($methods[2]->getNumberOfParameters())
+                    ->isEqualTo(0)
+                    ->isEqualTo($methods[2]->getNumberOfRequiredParameters())
+
+                ->let($return_type = $methods[2]->getReturnType())
+
+                ->string($return_type . '')
+                    ->isEqualTo('int')
+                ->boolean($return_type->allowsNull())
+                    ->isFalse()
+
+                ->string($methods[3]->getName())
+                    ->isEqualTo('offsetGet')
+                ->boolean($methods[3]->isPublic())
+                    ->isTrue()
+                ->integer($methods[3]->getNumberOfParameters())
+                    ->isEqualTo(1)
+                    ->isEqualTo($methods[3]->getNumberOfRequiredParameters())
+
+                ->let($parameters = $methods[3]->getParameters())
+
+                ->string($parameters[0]->getName())
+                    ->isEqualTo('offset')
+                ->boolean($parameters[0]->hasType())
+                    ->isFalse()
+
+                ->let($return_type = $methods[3]->getReturnType())
+
+                ->string($return_type . '')
+                    ->isEqualTo('number')
+                ->boolean($return_type->allowsNull())
+                    ->isFalse()
+
+                ->string($methods[4]->getName())
+                    ->isEqualTo('offsetSet')
+                ->boolean($methods[4]->isPublic())
+                    ->isTrue()
+                ->integer($methods[4]->getNumberOfParameters())
+                    ->isEqualTo(2)
+                    ->isEqualTo($methods[4]->getNumberOfRequiredParameters())
+
+                ->let($parameters = $methods[4]->getParameters())
+
+                ->string($parameters[0]->getName())
+                    ->isEqualTo('offset')
+                ->boolean($parameters[0]->hasType())
+                    ->isFalse()
+
+                ->string($parameters[1]->getName())
+                    ->isEqualTo('value')
+                ->boolean($parameters[1]->hasType())
+                    ->isFalse()
+
+                ->boolean($methods[4]->hasReturnType())
+                    ->isFalse()
+
+                ->string($methods[5]->getName())
+                    ->isEqualTo('offsetExists')
+                ->boolean($methods[5]->isPublic())
+                    ->isTrue()
+                ->integer($methods[5]->getNumberOfParameters())
+                    ->isEqualTo(1)
+                    ->isEqualTo($methods[5]->getNumberOfRequiredParameters())
+
+                ->let($parameters = $methods[5]->getParameters())
+
+                ->string($parameters[0]->getName())
+                    ->isEqualTo('offset')
+                ->boolean($parameters[0]->hasType())
+                    ->isFalse()
+
+                ->let($return_type = $methods[5]->getReturnType())
+
+                ->string($return_type . '')
+                    ->isEqualTo('bool')
+                ->boolean($return_type->allowsNull())
+                    ->isFalse()
+
+                ->string($methods[6]->getName())
+                    ->isEqualTo('offsetUnset')
+                ->boolean($methods[6]->isPublic())
+                    ->isTrue()
+                ->integer($methods[6]->getNumberOfParameters())
+                    ->isEqualTo(1)
+                    ->isEqualTo($methods[6]->getNumberOfRequiredParameters())
+
+                ->let($parameters = $methods[6]->getParameters())
+
+                ->string($parameters[0]->getName())
+                    ->isEqualTo('offset')
+                ->boolean($parameters[0]->hasType())
+                    ->isFalse()
+
+                ->boolean($methods[6]->hasReturnType())
+                    ->isFalse()
+
+                ->boolean($result->implementsInterface(ArrayAccess::class))
+                    ->isTrue()
+                ->boolean($result->getParentClass())
+                    ->isFalse()
+                ->array($result->getProperties())
+                    ->isEmpty()
+                ->string($result->getShortName())
+                    ->isEqualTo($wasmTypedArrayClassName)
+                ->array($result->getStaticProperties())
+                    ->isEmpty()
+                ->boolean($result->inNamespace())
+                    ->isFalse()
+                ->boolean($result->isAbstract())
+                    ->isFalse()
+                ->boolean($result->isAnonymous())
+                    ->isFalse()
+                ->boolean($result->isCloneable())
+                    ->isFalse()
+                ->boolean($result->isFinal())
+                    ->isTrue()
+                ->boolean($result->isInstantiable())
+                    ->isTrue()
+                ->boolean($result->isInternal())
+                    ->isTrue();
+    }
+
+    protected function wasm_typed_arrays()
+    {
+        yield [WasmInt8Array::class];
+        yield [WasmUint8Array::class];
+        yield [WasmInt16Array::class];
+        yield [WasmUint16Array::class];
+        yield [WasmInt32Array::class];
+        yield [WasmUint32Array::class];
     }
 
     public function test_wasm_array_buffer_constructor()

--- a/tests/units/Extension/Classes.php
+++ b/tests/units/Extension/Classes.php
@@ -297,7 +297,11 @@ class Classes extends Suite
                 ->boolean($parameters[0]->hasType())
                     ->isFalse()
 
-                ->boolean($methods[6]->hasReturnType())
+                ->let($return_type = $methods[6]->getReturnType())
+
+                ->string($return_type . '')
+                    ->isEqualTo('void')
+                ->boolean($return_type->allowsNull())
                     ->isFalse()
 
                 ->boolean($result->implementsInterface(ArrayAccess::class))

--- a/tests/units/Extension/Classes.php
+++ b/tests/units/Extension/Classes.php
@@ -667,7 +667,9 @@ class Classes extends Suite
                 ->integer($int8[3])
                     ->isEqualTo(0b01000000)
                 ->integer($int16[0])
-                    ->isEqualTo(0b000000010000000001)
+                    ->isEqualTo(0b0000010000000001)
+                ->integer($int16[1])
+                    ->isEqualTo(0b0100000000010000)
                 ->integer($int32[0])
                     ->isEqualTo(0b01000000000100000000010000000001);
     }
@@ -693,6 +695,8 @@ class Classes extends Suite
                    ->isEqualTo(0b00000000)
                 ->integer($uint16[0])
                    ->isEqualTo(0b000000000000000001)
+                ->integer($uint16[1])
+                   ->isEqualTo(0b000000000000000000)
                 ->integer($uint32[0])
                     ->isEqualTo(0b00000000000000000000000000000001);
     }

--- a/tests/units/Extension/Classes.php
+++ b/tests/units/Extension/Classes.php
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 
 namespace Wasm\Tests\Units\Extension;
 
+use ReflectionClass;
 use ReflectionExtension;
+use ReflectionMethod;
 use Wasm\Tests\Suite;
 
 class Classes extends Suite
@@ -27,12 +29,71 @@ class Classes extends Suite
             ->then
                 ->array($result)
                     ->hasSize(1)
+                    ->object['WasmArrayBuffer']->isInstanceOf(ReflectionClass::class)
 
-            ->when($result = $reflection->getClassNames())
+            ->when($_result = $result['WasmArrayBuffer'])
             ->then
-                ->array($result)
-                    ->isEqualTo([
-                        'WasmArrayBuffer',
-                    ]);
+                ->array($_result->getConstants())
+                    ->isEmpty()
+
+                ->let($methods = $_result->getMethods())
+
+                ->array($methods)
+                    ->hasSize(2)
+
+                ->string($methods[0]->getName())
+                    ->isEqualTo('__construct')
+                ->boolean($methods[0]->isPublic())
+                    ->isTrue()
+                ->integer($methods[0]->getNumberOfParameters())
+                    ->isEqualTo(1)
+                    ->isEqualTo($methods[0]->getNumberOfRequiredParameters())
+
+                ->let($parameters = $methods[0]->getParameters())
+
+                ->string($parameters[0]->getName())
+                    ->isEqualTo('byte_length')
+                ->string($parameters[0]->getType() . '')
+                    ->isEqualTo('int')
+                ->boolean($parameters[0]->getType()->allowsNull())
+                    ->isFalse()
+
+                ->string($methods[1]->getName())
+                    ->isEqualTo('getByteLength')
+                ->boolean($methods[1]->isPublic())
+                    ->isTrue()
+                ->integer($methods[1]->getNumberOfParameters())
+                    ->isEqualTo(0)
+                    ->isEqualTo($methods[1]->getNumberOfRequiredParameters())
+
+                ->let($return_type = $methods[1]->getReturnType())
+
+                ->string($return_type . '')
+                    ->isEqualTo('int')
+                ->boolean($return_type->allowsNull())
+                    ->isFalse()
+
+                ->boolean($_result->getParentClass())
+                    ->isFalse()
+                ->array($_result->getProperties())
+                    ->isEmpty()
+                ->string($_result->getShortName())
+                    ->isEqualTo('WasmArrayBuffer')
+                ->array($_result->getStaticProperties())
+                    ->isEmpty()
+                ->boolean($_result->inNamespace())
+                    ->isFalse()
+                ->boolean($_result->isAbstract())
+                    ->isFalse()
+                ->boolean($_result->isAnonymous())
+                    ->isFalse()
+                ->boolean($_result->isCloneable())
+                    ->isFalse()
+                ->boolean($_result->isFinal())
+                    ->isTrue()
+                ->boolean($_result->isInstantiable())
+                    ->isTrue()
+                ->boolean($_result->isInternal())
+                    ->isTrue();
     }
 }

--- a/tests/units/Extension/Classes.php
+++ b/tests/units/Extension/Classes.php
@@ -344,7 +344,7 @@ class Classes extends Suite
                 }
             )
                 ->isInstanceOf(Exception::class)
-                ->hasMessage('Buffer length must be positive.')
+                ->hasMessage('Buffer length must be positive; given 0.')
                 ->hasCode(0);
     }
 

--- a/tests/units/Extension/Classes.php
+++ b/tests/units/Extension/Classes.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Wasm\Tests\Units\Extension;
+
+use ReflectionExtension;
+use Wasm\Tests\Suite;
+
+class Classes extends Suite
+{
+    public function getTestedClassName()
+    {
+        return 'StdClass';
+    }
+
+    public function getTestedClassNamespace()
+    {
+        return '\\';
+    }
+
+    public function test_reflection_classes()
+    {
+        $this
+            ->given($reflection = new ReflectionExtension('wasm'))
+            ->when($result = $reflection->getClasses())
+            ->then
+                ->array($result)
+                    ->hasSize(1)
+
+            ->when($result = $reflection->getClassNames())
+            ->then
+                ->array($result)
+                    ->isEqualTo([
+                        'WasmArrayBuffer',
+                    ]);
+    }
+}

--- a/tests/units/Extension/Classes.php
+++ b/tests/units/Extension/Classes.php
@@ -257,7 +257,11 @@ class Classes extends Suite
                 ->boolean($parameters[1]->hasType())
                     ->isFalse()
 
-                ->boolean($methods[4]->hasReturnType())
+                ->let($return_type = $methods[4]->getReturnType())
+
+                ->string($return_type . '')
+                    ->isEqualTo('void')
+                ->boolean($return_type->allowsNull())
                     ->isFalse()
 
                 ->string($methods[5]->getName())

--- a/tests/units/Extension/Classes.php
+++ b/tests/units/Extension/Classes.php
@@ -357,7 +357,7 @@ class Classes extends Suite
                 }
             )
                 ->isInstanceOf(Exception::class)
-                ->hasMessage('Buffer length must be positive.')
+                ->hasMessage('Buffer length must be positive; given -1.')
                 ->hasCode(0);
     }
 

--- a/tests/units/Extension/Constants.php
+++ b/tests/units/Extension/Constants.php
@@ -5,13 +5,14 @@ declare(strict_types = 1);
 namespace Wasm\Tests\Units\Extension;
 
 use ReflectionExtension;
+use StdClass;
 use Wasm\Tests\Suite;
 
 class Constants extends Suite
 {
     public function getTestedClassName()
     {
-        return 'StdClass';
+        return StdClass::class;
     }
 
     public function getTestedClassNamespace()

--- a/tests/units/Extension/Constants.php
+++ b/tests/units/Extension/Constants.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Wasm\Tests\Units\Extension;
+
+use ReflectionExtension;
+use Wasm\Tests\Suite;
+
+class Constants extends Suite
+{
+    public function getTestedClassName()
+    {
+        return 'StdClass';
+    }
+
+    public function getTestedClassNamespace()
+    {
+        return '\\';
+    }
+
+    public function test_reflection_constants()
+    {
+        $this
+            ->given($reflection = new ReflectionExtension('wasm'))
+            ->when($result = $reflection->getConstants())
+            ->then
+                ->array($result)
+                    ->isEqualTo([
+                        'WASM_TYPE_I32' => 0,
+                        'WASM_TYPE_I64' => 1,
+                        'WASM_TYPE_F32' => 2,
+                        'WASM_TYPE_F64' => 3,
+                    ]);
+    }
+}

--- a/tests/units/Extension/Dependencies.php
+++ b/tests/units/Extension/Dependencies.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Wasm\Tests\Units\Extension;
+
+use ReflectionExtension;
+use Wasm\Tests\Suite;
+
+class Dependencies extends Suite
+{
+    public function getTestedClassName()
+    {
+        return 'StdClass';
+    }
+
+    public function getTestedClassNamespace()
+    {
+        return '\\';
+    }
+
+    public function test_reflection_dependencies()
+    {
+        $this
+            ->given($reflection = new ReflectionExtension('wasm'))
+            ->when($result = $reflection->getDependencies())
+            ->then
+                ->array($result)
+                    ->isEmpty();
+    }
+}

--- a/tests/units/Extension/Dependencies.php
+++ b/tests/units/Extension/Dependencies.php
@@ -5,13 +5,14 @@ declare(strict_types = 1);
 namespace Wasm\Tests\Units\Extension;
 
 use ReflectionExtension;
+use StdClass;
 use Wasm\Tests\Suite;
 
 class Dependencies extends Suite
 {
     public function getTestedClassName()
     {
-        return 'StdClass';
+        return StdClass::class;
     }
 
     public function getTestedClassNamespace()

--- a/tests/units/Extension/Functions.php
+++ b/tests/units/Extension/Functions.php
@@ -7,6 +7,7 @@ namespace Wasm\Tests\Units\Extension;
 use ReflectionExtension;
 use ReflectionFunction;
 use RuntimeException;
+use StdClass;
 use Wasm\Tests\Suite;
 
 class Functions extends Suite
@@ -15,7 +16,7 @@ class Functions extends Suite
 
     public function getTestedClassName()
     {
-        return 'StdClass';
+        return StdClass::class;
     }
 
     public function getTestedClassNamespace()

--- a/tests/units/Extension/Functions.php
+++ b/tests/units/Extension/Functions.php
@@ -2,16 +2,16 @@
 
 declare(strict_types = 1);
 
-namespace Wasm\Tests\Units;
+namespace Wasm\Tests\Units\Extension;
 
 use ReflectionExtension;
 use ReflectionFunction;
 use RuntimeException;
 use Wasm\Tests\Suite;
 
-class Extension extends Suite
+class Functions extends Suite
 {
-    const FILE_PATH = __DIR__ . '/tests.wasm';
+    const FILE_PATH = __DIR__ . '/../tests.wasm';
 
     public function getTestedClassName()
     {
@@ -21,46 +21,6 @@ class Extension extends Suite
     public function getTestedClassNamespace()
     {
         return '\\';
-    }
-
-    public function test_reflection_classes()
-    {
-        $this
-            ->given($reflection = new ReflectionExtension('wasm'))
-            ->when($result = $reflection->getClasses())
-            ->then
-                ->array($result)
-                    ->isEmpty()
-
-            ->when($result = $reflection->getClassNames())
-            ->then
-                ->array($result)
-                    ->isEmpty();
-    }
-
-    public function test_reflection_constants()
-    {
-        $this
-            ->given($reflection = new ReflectionExtension('wasm'))
-            ->when($result = $reflection->getConstants())
-            ->then
-                ->array($result)
-                    ->isEqualTo([
-                        'WASM_TYPE_I32' => 0,
-                        'WASM_TYPE_I64' => 1,
-                        'WASM_TYPE_F32' => 2,
-                        'WASM_TYPE_F64' => 3,
-                    ]);
-    }
-
-    public function test_reflection_dependencies()
-    {
-        $this
-            ->given($reflection = new ReflectionExtension('wasm'))
-            ->when($result = $reflection->getDependencies())
-            ->then
-                ->array($result)
-                    ->isEmpty();
     }
 
     public function test_reflection_functions()
@@ -365,36 +325,6 @@ class Extension extends Suite
                     ->isTrue();
     }
 
-    public function test_reflection_ini_entries()
-    {
-        $this
-            ->given($reflection = new ReflectionExtension('wasm'))
-            ->when($result = $reflection->getINIEntries())
-            ->then
-                ->array($result)
-                    ->isEmpty();
-    }
-
-    public function test_reflection_name()
-    {
-        $this
-            ->given($reflection = new ReflectionExtension('wasm'))
-            ->when($result = $reflection->getName())
-            ->then
-                ->string($result)
-                    ->isEqualTo('wasm');
-    }
-
-    public function test_reflection_version()
-    {
-        $this
-            ->given($reflection = new ReflectionExtension('wasm'))
-            ->when($result = $reflection->getVersion())
-            ->then
-                ->string($result)
-                    ->isEqualTo('0.2.0');
-    }
-
     public function test_wasm_fetch_bytes()
     {
         $this
@@ -447,7 +377,7 @@ class Extension extends Suite
     public function test_wasm_compile_invalid_bytes()
     {
         $this
-            ->given($wasmBytes = wasm_fetch_bytes(__DIR__ . '/invalid.wasm'))
+            ->given($wasmBytes = wasm_fetch_bytes(dirname(__DIR__) . '/invalid.wasm'))
             ->when($result = wasm_compile($wasmBytes))
             ->then
                 ->variable($result)
@@ -511,20 +441,6 @@ class Extension extends Suite
                         'If this is failing, it means that the bytes are read, ' .
                         'and that the module is compiled again, which is not good.'
                     );
-    }
-
-    public function test_wasm_module_clean_up_persistent_resources()
-    {
-        $this
-            ->given(
-                $wasmBytes = wasm_fetch_bytes(self::FILE_PATH),
-                $wasmModuleIdentifier = __METHOD__,
-                $wasmModule = wasm_compile($wasmBytes, $wasmModuleIdentifier),
-            )
-            ->when($result = wasm_module_clean_up_persistent_resources())
-            ->then
-                ->variable($result)
-                    ->isNull();
     }
 
     public function test_wasm_module_serialize()

--- a/tests/units/Extension/IniEntries.php
+++ b/tests/units/Extension/IniEntries.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Wasm\Tests\Units\Extension;
+
+use ReflectionExtension;
+use Wasm\Tests\Suite;
+
+class IniEntries extends Suite
+{
+    public function getTestedClassName()
+    {
+        return 'StdClass';
+    }
+
+    public function getTestedClassNamespace()
+    {
+        return '\\';
+    }
+
+    public function test_reflection_ini_entries()
+    {
+        $this
+            ->given($reflection = new ReflectionExtension('wasm'))
+            ->when($result = $reflection->getINIEntries())
+            ->then
+                ->array($result)
+                    ->isEmpty();
+    }
+}

--- a/tests/units/Extension/IniEntries.php
+++ b/tests/units/Extension/IniEntries.php
@@ -5,13 +5,14 @@ declare(strict_types = 1);
 namespace Wasm\Tests\Units\Extension;
 
 use ReflectionExtension;
+use StdClass;
 use Wasm\Tests\Suite;
 
 class IniEntries extends Suite
 {
     public function getTestedClassName()
     {
-        return 'StdClass';
+        return StdClass::class;
     }
 
     public function getTestedClassNamespace()

--- a/tests/units/Extension/Name.php
+++ b/tests/units/Extension/Name.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Wasm\Tests\Units\Extension;
+
+use ReflectionExtension;
+use Wasm\Tests\Suite;
+
+class Name extends Suite
+{
+    public function getTestedClassName()
+    {
+        return 'StdClass';
+    }
+
+    public function getTestedClassNamespace()
+    {
+        return '\\';
+    }
+
+    public function test_reflection_name()
+    {
+        $this
+            ->given($reflection = new ReflectionExtension('wasm'))
+            ->when($result = $reflection->getName())
+            ->then
+                ->string($result)
+                    ->isEqualTo('wasm');
+    }
+}

--- a/tests/units/Extension/Name.php
+++ b/tests/units/Extension/Name.php
@@ -5,13 +5,14 @@ declare(strict_types = 1);
 namespace Wasm\Tests\Units\Extension;
 
 use ReflectionExtension;
+use StdClass;
 use Wasm\Tests\Suite;
 
 class Name extends Suite
 {
     public function getTestedClassName()
     {
-        return 'StdClass';
+        return StdClass::class;
     }
 
     public function getTestedClassNamespace()

--- a/tests/units/Extension/Version.php
+++ b/tests/units/Extension/Version.php
@@ -5,13 +5,14 @@ declare(strict_types = 1);
 namespace Wasm\Tests\Units\Extension;
 
 use ReflectionExtension;
+use StdClass;
 use Wasm\Tests\Suite;
 
 class Version extends Suite
 {
     public function getTestedClassName()
     {
-        return 'StdClass';
+        return StdClass::class;
     }
 
     public function getTestedClassNamespace()

--- a/tests/units/Extension/Version.php
+++ b/tests/units/Extension/Version.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Wasm\Tests\Units\Extension;
+
+use ReflectionExtension;
+use Wasm\Tests\Suite;
+
+class Version extends Suite
+{
+    public function getTestedClassName()
+    {
+        return 'StdClass';
+    }
+
+    public function getTestedClassNamespace()
+    {
+        return '\\';
+    }
+
+    public function test_reflection_version()
+    {
+        $this
+            ->given($reflection = new ReflectionExtension('wasm'))
+            ->when($result = $reflection->getVersion())
+            ->then
+                ->string($result)
+                    ->isEqualTo('0.2.0');
+    }
+}


### PR DESCRIPTION
Implement `WasmArrayBuffer` and `WasmTypedArray` classes i.e. `WasmInt8Array`, `WasmUint8Array`, `WasmInt16Array`, `WasmUint16Array`, `WasmInt32Array` and `WasmUint32Array`.

Prototype:

```php
final class WasmArrayBuffer
{
    public function __construct(int $byte_length);
    public function getByteLength(): int;
}

final class WasmUint8Array implements ArrayAccess
{
    public const BYTES_PER_ELEMENT;
    
    public function __construct(WasmArrayBuffer $wasm_array_buffer, int $offset = 0, int $length = 0);
    public function getOffset(): int;
    public function getLength(): int;

    /* For `ArrayAccess` */
    public function offsetGet($offset): int;
    public function offsetSet($offset, $value);
    public function offsetExists($offset): bool;
    public function offsetUnset($offset);
}
```

Example:

```php
$wasmArrayBuffer = new WasmArrayBuffer(256);
$int8 = new WasmInt8Array($wasmArrayBuffer);
$int16 = new WasmInt16Array($wasmArrayBuffer);
$int32 = new WasmInt32Array($wasmArrayBuffer);

                b₁
             ┌┬┬┬┬┬┬┐
$int8[0] = 0b00000001;
                b₂
             ┌┬┬┬┬┬┬┐
$int8[1] = 0b00000100;
                b₃
             ┌┬┬┬┬┬┬┐
$int8[2] = 0b00010000;
                b₄
             ┌┬┬┬┬┬┬┐
$int8[3] = 0b01000000;

// No surprise with the following assertions.
                         b₁
                      ┌┬┬┬┬┬┬┐
assert($int8[0] === 0b00000001);
                         b₂
                      ┌┬┬┬┬┬┬┐
assert($int8[1] === 0b00000100);
                         b₃
                      ┌┬┬┬┬┬┬┐
assert($int8[2] === 0b00010000);
                         b₄
                      ┌┬┬┬┬┬┬┐
assert($int8[3] === 0b01000000);

// The `int16` view read 2 bytes.
                          b₂      b₁
                       ┌┬┬┬┬┬┬┐┌┬┬┬┬┬┬┐
assert($int16[0] === 0b0000010000000001);
                          b₄      b₃
                       ┌┬┬┬┬┬┬┐┌┬┬┬┬┬┬┐
assert($int16[1] === 0b0100000000010000);

// The `int32` view reads 4 bytes.
                          b₄      b₃      b₂      b₁
                       ┌┬┬┬┬┬┬┐┌┬┬┬┬┬┬┐┌┬┬┬┬┬┬┐┌┬┬┬┬┬┬┐
assert($int32[0] === 0b01000000000100000000010000000001);
```

The code is highly inspired by http://www.phpinternalsbook.com/classes_objects/implementing_typed_arrays.html, with bug fixes and written for Zend Engine 3.