### PR TITLE
feat(lib) Implement `Instance::getMemoryBuffer`

### DIFF
--- a/examples/memory.php
+++ b/examples/memory.php
@@ -2,17 +2,17 @@
 
 declare(strict_types = 1);
 
-$bytes = wasm_fetch_bytes(__DIR__ . '/memory.wasm');
-$instance = wasm_new_instance($bytes);
-$pointer = wasm_invoke_function($instance, 'return_hello', []);
+require_once dirname(__DIR__) . '/vendor/autoload.php';
 
-$memory = wasm_get_memory_buffer($instance);
-$view = new WasmUint8Array($memory, $pointer);
+$instance = new Wasm\Instance(__DIR__ . '/memory.wasm');
+$pointer = $instance->return_hello();
+
+$memory = new Wasm\Uint8Array($instance->getMemoryBuffer(), $pointer);
 
 $nth = 0;
 
-while (0 !== $view[$nth]) {
-    echo chr($view[$nth]);
+while (0 !== $memory[$nth]) {
+    echo chr($memory[$nth]);
     ++$nth;
 }
 

--- a/examples/memory.rs
+++ b/examples/memory.rs
@@ -1,4 +1,4 @@
 #[no_mangle]
-pub extern "C" fn return_hello() -> *const u8 {
-    b"Hello, World!\0"[..].as_ptr()
+pub extern fn return_hello() -> *const u8 {
+    b"Hello, World!\0".as_ptr()
 }

--- a/lib/Instance.php
+++ b/lib/Instance.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Wasm;
 
 use RuntimeException;
+use WasmArrayBuffer;
 
 /**
  * The `Instance` class allows to compile WebAssembly bytes into a module, and
@@ -31,6 +32,11 @@ class Instance
      * The Wasm instance.
      */
     protected $wasmInstance;
+
+    /**
+     * A Wasm buffer over the instance memory if any.
+     */
+    protected $wasmMemoryBuffer;
 
     /**
      * Compiles and instantiates a WebAssembly binary file.
@@ -92,6 +98,30 @@ class Instance
                 }
             }
         };
+    }
+
+    /**
+     * Returns an array buffer over the instance memory if any.
+     *
+     * It is recommended to combine the array buffer with typed arrays
+     * `Wasm\TypedArray`.
+     *
+     * # Examples
+     *
+     * ```php,ignore
+     * $instance = new Wasm\Instance('my_program.wasm');
+     * $memory = $instance->getMemoryBuffer();
+     *
+     * assert($memory instanceof WasmArrayBuffer);
+     * ```
+     */
+    public function getMemoryBuffer(): ?WasmArrayBuffer
+    {
+        if (null === $this->wasmMemoryBuffer) {
+            $this->wasmMemoryBuffer = wasm_get_memory_buffer($this->wasmInstance);
+        }
+
+        return $this->wasmMemoryBuffer;
     }
 
     /**

--- a/tests/units/tests.rs
+++ b/tests/units/tests.rs
@@ -1,44 +1,44 @@
 #[no_mangle]
-pub extern "C" fn sum(x: i32, y: i32) -> i32 {
+pub extern fn sum(x: i32, y: i32) -> i32 {
     x + y
 }
 
 #[no_mangle]
-pub extern "C" fn arity_0() -> i32 {
+pub extern fn arity_0() -> i32 {
     42
 }
 
 #[no_mangle]
-pub extern "C" fn i32_i32(x: i32) -> i32 {
+pub extern fn i32_i32(x: i32) -> i32 {
     x
 }
 
 #[no_mangle]
-pub extern "C" fn i64_i64(x: i64) -> i64 {
+pub extern fn i64_i64(x: i64) -> i64 {
     x
 }
 
 #[no_mangle]
-pub extern "C" fn f32_f32(x: f32) -> f32 {
+pub extern fn f32_f32(x: f32) -> f32 {
     x
 }
 
 #[no_mangle]
-pub extern "C" fn f64_f64(x: f64) -> f64 {
+pub extern fn f64_f64(x: f64) -> f64 {
     x
 }
 
 #[no_mangle]
-pub extern "C" fn i32_i64_f32_f64_f64(a: i32, b: i64, c: f32, d: f64) -> f64 {
+pub extern fn i32_i64_f32_f64_f64(a: i32, b: i64, c: f32, d: f64) -> f64 {
     a as f64 + b as f64 + c as f64 + d
 }
 
 #[no_mangle]
-pub extern "C" fn bool_casted_to_i32() -> bool {
+pub extern fn bool_casted_to_i32() -> bool {
     true
 }
 
 #[no_mangle]
-pub extern "C" fn string() -> *const u8 {
+pub extern fn string() -> *const u8 {
     b"Hello, World!\0".as_ptr()
 }


### PR DESCRIPTION
Sequel of #37.

Implement `Wasm\Instance::getMemoryBuffer`:

```php
public function getMemoryBuffer(): ?WasmArrayBuffer;
```

Usage example:

```php
$instance = new Wasm\Instance(__DIR__ . '/memory.wasm');
$pointer = $instance->return_hello();

$memory = new Wasm\Uint8Array($instance->getMemoryBuffer(), $pointer);

$nth = 0;

while (0 !== $memory[$nth]) {
    echo chr($memory[$nth]);
    ++$nth;
}

echo "\n";
```