### PR TITLE
chore(runtime) Update Wasmer to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,4 @@ categories = ["wasm"]
 [lib]
 
 [dependencies]
-wasmer-runtime-c-api = { git = "https://github.com/wasmerio/wasmer", branch = "master" }
-
-[build-dependencies]
-walkdir = "2.2"
+wasmer-runtime-c-api = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
+publish = false
 name = "php-ext-wasm"
 version = "0.3.0"
 authors = ["Ivan Enderlin <ivan.enderlin@hoa-project.net>"]
 edition = "2018"
+description = "PHP extension to run WebAssembly binaries"
+readme = "README.md"
+repository = "https://github.com/wasmer/php-ext-wasm"
+keywords = ["php", "extension", "webassembly"]
+categories = ["wasm"]
 
 [lib]
 

--- a/extension/libwasmer_runtime_c_api.a
+++ b/extension/libwasmer_runtime_c_api.a
@@ -1,1 +1,1 @@
-../target/release/deps/libwasmer_runtime_c_api.a
+../target/release/deps/libwasmer_runtime_c_api-11c746fd5153053f.a

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ php:
 	make install
 
 # Run PHP tests.
-test-php:
+test:
 	composer test
 
 # Generate the documentation.

--- a/tests/units/Instance.php
+++ b/tests/units/Instance.php
@@ -149,7 +149,7 @@ class Instance extends Suite
                 ->isInstanceOf(InvocationException::class)
                 ->hasMessage(
                     'Missing 1 argument(s) when calling `sum`: ' .
-                    'Expect 2 arguments, given 1.'
+                    'Expect 2 argument(s), given 1.'
                 );
     }
 
@@ -165,7 +165,7 @@ class Instance extends Suite
                 ->isInstanceOf(InvocationException::class)
                 ->hasMessage(
                     'Given 1 extra argument(s) when calling `sum`: ' .
-                    'Expect 2 arguments, given 3.'
+                    'Expect 2 argument(s), given 3.'
                 );
     }
 


### PR DESCRIPTION
Fix #41.

This patch updates the runtime to 0.3.0. In addition, run some cleanups.