### PR TITLE
fix(lib) Fix error when invoking a function + fix memory buffer

### DIFF
--- a/lib/Instance.php
+++ b/lib/Instance.php
@@ -236,8 +236,10 @@ class Instance
             $wasmArguments
         );
 
-        if (false === $result) {
-            throw new InvocationException("Got an error when invoking `$name`.");
+        if (null === $result) {
+            $error = wasm_get_last_error();
+
+            throw new InvocationException("Got an error when invoking `$name`: $error");
         }
 
         return $result;

--- a/lib/Instance.php
+++ b/lib/Instance.php
@@ -34,11 +34,6 @@ class Instance
     protected $wasmInstance;
 
     /**
-     * A Wasm buffer over the instance memory if any.
-     */
-    protected $wasmMemoryBuffer;
-
-    /**
      * Compiles and instantiates a WebAssembly binary file.
      *
      * The constructor throws a `RuntimeException` when the given file does
@@ -117,11 +112,7 @@ class Instance
      */
     public function getMemoryBuffer(): ?WasmArrayBuffer
     {
-        if (null === $this->wasmMemoryBuffer) {
-            $this->wasmMemoryBuffer = wasm_get_memory_buffer($this->wasmInstance);
-        }
-
-        return $this->wasmMemoryBuffer;
+        return wasm_get_memory_buffer($this->wasmInstance);
     }
 
     /**

--- a/tests/units/TypedArray.php
+++ b/tests/units/TypedArray.php
@@ -16,6 +16,8 @@ use Wasm\Tests\Suite;
 
 class TypedArray extends Suite
 {
+    const FILE_PATH = __DIR__ . '/tests.wasm';
+
     /**
      * @dataProvider typed_arrays
      */
@@ -28,6 +30,23 @@ class TypedArray extends Suite
                 ->object($result)
                     ->isInstanceOf($wasmTypedArrayName)
                     ->isInstanceof(LUT\TypedArray::class);
+    }
+
+    /**
+     * @dataProvider typed_arrays
+     */
+    public function test_length(string $typedArrayName)
+    {
+        $this
+            ->given(
+                $instance = new LUT\Instance(static::FILE_PATH),
+                $memoryBuffer = $instance->getMemoryBuffer(),
+                $memoryBufferByteLength = $memoryBuffer->getByteLength()
+            )
+            ->when($typedArray = new $typedArrayName($memoryBuffer))
+            ->then
+                ->integer($typedArray->getLength())
+                    ->isEqualTo($memoryBuffer->getByteLength() / $typedArrayName::BYTES_PER_ELEMENT);
     }
 
     protected function typed_arrays()


### PR DESCRIPTION
This PR is twofold:

1. Fix error raising when invoking a function fails (`wasm_invoke_funciton` no longer returns `false`,  but only `null`),
2. `Instance::getMemoryBuffer` no longer caches the result.