### PR TITLE
test(benchmarks) Add the `InvokeFunction` benchmark

### DIFF
--- a/benchmarks/invoke_function.php
+++ b/benchmarks/invoke_function.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * @BeforeMethods({"initialize"})
+ * @Warmup(2)
+ * @Revs(1000)
+ * @Iterations(10)
+ * @OutputTimeUnit("microseconds", precision=3)
+ * @OutputMode("time")
+ */
+class InvokeFunction
+{
+    private $wasmInstance = null;
+
+    public function initialize(array $parameters = [])
+    {
+        $this->wasmInstance = new Wasm\Instance(__DIR__ . '/../tests/units/tests.wasm');
+    }
+
+    public function bench_invoke_sum()
+    {
+        return $this->wasmInstance->sum(1, 2);
+    }
+
+    public function bench_invoke_i32_i64_f32_f64_f64()
+    {
+        return $this->wasmInstance->i32_i64_f32_f64_f64(1, 2, 3., 4.);
+    }
+
+}


### PR DESCRIPTION
This benchmark aims at showing the improvement made in
https://github.com/wasmerio/php-ext-wasm/pull/54.

Before #54:

| subject | mem_peak   | mean     | mode     | best     |
|-|-|-|-|-|
| bench_invoke_sum                 | 1,437,376b | 10.450μs | 10.350μs | 10.237μs |
| bench_invoke_i32_i64_f32_f64_f64 | 1,437,376b | 11.204μs | 11.076μs | 10.922μs |

After:

| subject | mem_peak   | mean    | mode    | best    |
|-|-|-|-|-|
| bench_invoke_sum                 | 1,421,560b | 9.431μs | 9.384μs | 9.297μs |
| bench_invoke_i32_i64_f32_f64_f64 | 1,421,560b | 9.419μs | 9.399μs | 9.342μs |

We can observe that invoking an exported function is between 9.8% to 15.9%
faster. Memory usage is also 1% smaller, bonus.