### PR TITLE
feat(memory) Add the `WasmArrayBuffer::grow` method

### DIFF
--- a/extension/wasm.cc
+++ b/extension/wasm.cc
@@ -171,6 +171,10 @@ PHP_METHOD(WasmArrayBuffer, grow)
 
     wasm_array_buffer_object *wasm_array_buffer_object = WASM_ARRAY_BUFFER_OBJECT_THIS();
 
+    if (wasm_array_buffer_object->allocated_buffer == true) {
+        RETURN_NULL();
+    }
+
     wasmer_result_t wasm_memory_grow_result = wasmer_memory_grow(
         wasm_array_buffer_object->memory,
         // Number of pages.

--- a/extension/wasm.hh
+++ b/extension/wasm.hh
@@ -53,6 +53,10 @@ zend_object_handlers wasm_array_buffer_class_entry_handlers;
  * Custom object for the `WasmArrayBuffer` class.
  */
 typedef struct {
+    // The internal opaque exports pointer. It contains the data of
+    // the `wasmer_memory_t`.
+    wasmer_exports_t *exports;
+
     // The internal opaque memory pointer.
     wasmer_memory_t *memory;
 

--- a/extension/wasm.hh
+++ b/extension/wasm.hh
@@ -53,6 +53,9 @@ zend_object_handlers wasm_array_buffer_class_entry_handlers;
  * Custom object for the `WasmArrayBuffer` class.
  */
 typedef struct {
+    // The internal opaque memory pointer.
+    wasmer_memory_t *memory;
+
     // The internal buffer.
     int8_t *buffer;
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -333,6 +333,7 @@ final class WasmArrayBuffer
 {
     public function __construct(int $byte_length);
     public function getByteLength(): int;
+    public function grow(int $number_of_pages): void;
 }
 ```
 

--- a/tests/units/Extension/Classes.php
+++ b/tests/units/Extension/Classes.php
@@ -60,7 +60,7 @@ class Classes extends Suite
                 ->let($methods = $result->getMethods())
 
                 ->array($methods)
-                    ->hasSize(2)
+                    ->hasSize(3)
 
                 ->string($methods[0]->getName())
                     ->isEqualTo('__construct')
@@ -91,6 +91,30 @@ class Classes extends Suite
 
                 ->string($return_type . '')
                     ->isEqualTo('int')
+                ->boolean($return_type->allowsNull())
+                    ->isFalse()
+
+                ->string($methods[2]->getName())
+                    ->isEqualTo('grow')
+                ->boolean($methods[2]->isPublic())
+                    ->isTrue()
+                ->integer($methods[2]->getNumberOfParameters())
+                    ->isEqualTo(1)
+                    ->isEqualTo($methods[2]->getNumberOfRequiredParameters())
+
+                ->let($parameters = $methods[2]->getParameters())
+
+                ->string($parameters[0]->getName())
+                    ->isEqualTo('number_of_pages')
+                ->string($parameters[0]->getType() . '')
+                    ->isEqualTo('int')
+                ->boolean($parameters[0]->getType()->allowsNull())
+                    ->isFalse()
+
+                ->let($return_type = $methods[2]->getReturnType())
+
+                ->string($return_type . '')
+                    ->isEqualTo('void')
                 ->boolean($return_type->allowsNull())
                     ->isFalse()
 

--- a/tests/units/Extension/Classes.php
+++ b/tests/units/Extension/Classes.php
@@ -407,6 +407,22 @@ class Classes extends Suite
                     ->isEqualTo($byteLength);
     }
 
+    public function test_wasm_array_buffer_grow()
+    {
+        $this
+            ->given(
+                $byteLength = 1114112,
+                $wasmArrayBuffer = new WasmArrayBuffer($byteLength),
+            )
+            ->when($result = $wasmArrayBuffer->grow(1))
+            ->then
+                ->variable($result)
+                    ->isNull()
+                // Does nothing because it's not Wasm memory, just an allocated buffer.
+                ->integer($wasmArrayBuffer->getByteLength())
+                    ->isEqualTo($byteLength);
+    }
+
     /**
      * @dataProvider wasm_typed_arrays
      */

--- a/tests/units/Instance.php
+++ b/tests/units/Instance.php
@@ -114,6 +114,30 @@ class Instance extends Suite
                     ->isEqualTo('Hello, World!');
     }
 
+    public function test_grow_memory_buffer()
+    {
+        $this
+            ->given(
+                $wasmInstance = new SUT(self::FILE_PATH),
+                $memory = $wasmInstance->getMemoryBuffer(),
+                $oldMemoryLength = $memory->getByteLength()
+            )
+            ->when($result = $memory->grow(1))
+            ->then
+                ->variable($result)
+                    ->isNull()
+                ->integer($oldMemoryLength)
+                    ->isEqualTo(1114112)
+
+                ->let($memoryLength = $memory->getByteLength())
+
+                ->integer($memoryLength)
+                    ->isEqualTo(1179648)
+
+                ->integer($memoryLength - $oldMemoryLength)
+                    ->isEqualTo(65536);
+    }
+
     public function test_basic_sum()
     {
         $this

--- a/tests/units/Instance.php
+++ b/tests/units/Instance.php
@@ -138,6 +138,20 @@ class Instance extends Suite
                     ->isEqualTo(65536);
     }
 
+    public function test_grow_memory_buffer_too_much()
+    {
+        $this
+            ->given(
+                $wasmInstance = new SUT(self::FILE_PATH),
+                $memory = $wasmInstance->getMemoryBuffer()
+            )
+            ->exception(function () use ($memory) {
+                $memory->grow(100000);
+            })
+                ->isInstanceOf(\Exception::class)
+                ->hasMessage('Failed to grow the memory.');
+    }
+
     public function test_basic_sum()
     {
         $this


### PR DESCRIPTION
This method allows to grow the WebAssembly memory by a number of pages (65kb each).