### PR TITLE
feat(instance) Introduce the `wasm_instance` structure

### DIFF
--- a/extension/wasm.hh
+++ b/extension/wasm.hh
@@ -53,10 +53,6 @@ zend_object_handlers wasm_array_buffer_class_entry_handlers;
  * Custom object for the `WasmArrayBuffer` class.
  */
 typedef struct {
-    // The internal opaque exports pointer. It contains the data of
-    // the `wasmer_memory_t`.
-    wasmer_exports_t *exports;
-
     // The internal opaque memory pointer.
     wasmer_memory_t *memory;
 

--- a/extension/wasm.hh
+++ b/extension/wasm.hh
@@ -154,9 +154,20 @@ const char* wasm_instance_resource_name;
 int wasm_instance_resource_number;
 
 /**
+ * Represents an `instance` with regular data.
+ */
+typedef struct {
+    // The internal opaque instance pointer.
+    wasmer_instance_t *instance;
+
+    // The internal opaque exports pointer.
+    wasmer_exports_t *exports;
+} wasm_instance;
+
+/**
  * Extract the data structure inside the `wasm_instance` resource.
  */
-wasmer_instance_t *wasm_instance_from_resource(zend_resource *wasm_instance_resource);
+wasm_instance *wasm_instance_from_resource(zend_resource *wasm_instance_resource);
 
 /**
  * Destructor for the `wasm_instance` resource.


### PR DESCRIPTION
This PR introduces a `wasm_instance` structure. It holds a `wasmer_instance_t` pointer and a `wasmer_exports_t` pointer. Thus, it simplifies the `WasmArrayBuffer` internal structure that also contained a `wasmer_exports_t` pointer (see #68).

It simplifies the code since we don't have to destroy the exports everytime an error happens. Exports need to be destroyed only when the `wasm_instance` _resource_ is destroyed.

It finally avoids an allocation for exports everytime an exported function is invoked.