### PR TITLE
feat(extension) Be compatibel with prior PHP versions (i.e. 7.2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,65 +1,74 @@
 version: 2.1
 
+build_and_test_steps: &build_and_test_steps
+  # Update the project.
+  - checkout
+
+  # Install Rust.
+  - run:
+      name: Install Rust
+      command: |
+        test -d /usr/local/cargo || curl https://sh.rustup.rs -sSf | sh -s -- -y
+
+  # Install `just` used to manage the project.
+  - run:
+      name: Install just
+      command: |
+        export PATH="$HOME/.cargo/bin:$PATH"
+        test -f $HOME/.cargo/bin/just || cargo install just
+
+  # Install Composer.
+  - run:
+      name: Install Composer
+      command: |
+        php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+        php composer-setup.php
+        php -r "unlink('composer-setup.php');"
+        mv composer.phar composer
+
+  # Compile and install the PHP extension.
+  # `just build` isn't used because there is no some issue with
+  # `--with-pic` I don't understand…
+  - run:
+      name: Compile and install the PHP extension
+      command: |
+        export PATH="$HOME/.cargo/bin:$PATH"
+        export CXX="gcc"
+        EXTENSION="$HOME/project/src"
+        cd $EXTENSION
+        PHP_PREFIX=$(php-config --prefix)
+        PHP_PREFIX_BIN=$PHP_PREFIX/bin
+        $PHP_PREFIX_BIN/phpize --clean
+        $PHP_PREFIX_BIN/phpize
+        ./configure --with-php-config=$PHP_PREFIX_BIN/php-config
+        /bin/bash $EXTENSION/libtool --mode=compile $CXX -I. -I$EXTENSION -DPHP_ATOM_INC -I$EXTENSION/include -I$EXTENSION/main -I$EXTENSION -I$PHP_PREFIX/include/php -I$PHP_PREFIX/include/php/main -I$PHP_PREFIX/include/php/TSRM -I$PHP_PREFIX/include/php/Zend -I$PHP_PREFIX/include/php/ext -I$PHP_PREFIX/include/php/ext/date/lib -DHAVE_CONFIG_H -c $EXTENSION/wasm.cc -o wasm.lo -fPIC
+        $CXX -I. -I$EXTENSION -DPHP_ATOM_INC -I$EXTENSION/include -I$EXTENSION/main -I$EXTENSION -I$PHP_PREFIX/include/php -I$PHP_PREFIX/include/php/main -I$PHP_PREFIX/include/php/TSRM -I$PHP_PREFIX/include/php/Zend -I$PHP_PREFIX/include/php/ext -I$PHP_PREFIX/include/php/ext/date/lib -DHAVE_CONFIG_H -c $EXTENSION/wasm.cc  -DPIC -o .libs/wasm.o -fPIC
+        /bin/bash $EXTENSION/libtool --mode=link cc -DPHP_ATOM_INC -I$EXTENSION/include -I$EXTENSION/main -I$EXTENSION -I$PHP_PREFIX/include/php -I$PHP_PREFIX/include/php/main -I$PHP_PREFIX/include/php/TSRM -I$PHP_PREFIX/include/php/Zend -I$PHP_PREFIX/include/php/ext -I$PHP_PREFIX/include/php/ext/date/lib  -DHAVE_CONFIG_H  -g -O2    -o wasm.la -export-dynamic -avoid-version -prefer-pic -module -rpath $EXTENSION/modules  wasm.lo -Wl,-rpath,$EXTENSION/. -L$EXTENSION/. -lwasmer_runtime_c_api -fPIC
+        cc -shared  .libs/wasm.o  -L$EXTENSION/. -lwasmer_runtime_c_api  -Wl,-rpath -Wl,$EXTENSION/. -Wl,-soname -Wl,wasm.so -o .libs/wasm.so -fPIC
+        sudo make install-modules
+
+  # Run the extension test suites.
+  - run:
+      name: Test the extension
+      command: |
+        export PATH="$HOME/.cargo/bin:$PATH"
+        composer install --no-progress
+        vendor/bin/atoum --php 'php -d extension=wasm' --directories tests/units --force-terminal --use-dot-report
+  
+
 # List of all jobs.
 jobs:
-  # Build and test the project the project.
-  build_and_test:
+  # Build and test the project the project against the latest PHP version.
+  build_and_test_php_latest:
     docker:
       - image: circleci/php:latest
-    steps:
-      # Update the project.
-      - checkout
+    steps: *build_and_test_steps
 
-      # Install Rust.
-      - run:
-          name: Install Rust
-          command: |
-            test -d /usr/local/cargo || curl https://sh.rustup.rs -sSf | sh -s -- -y
-
-      # Install `just` used to manage the project.
-      - run:
-          name: Install just
-          command: |
-            export PATH="$HOME/.cargo/bin:$PATH"
-            test -f $HOME/.cargo/bin/just || cargo install just
-
-      # Install Composer.
-      - run:
-          name: Install Composer
-          command: |
-            php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-            php composer-setup.php
-            php -r "unlink('composer-setup.php');"
-            mv composer.phar composer
-
-      # Compile and install the PHP extension.
-      # `just build` isn't used because there is no some issue with
-      # `--with-pic` I don't understand…
-      - run:
-          name: Compile and install the PHP extension
-          command: |
-            export PATH="$HOME/.cargo/bin:$PATH"
-            export CXX="gcc"
-            EXTENSION="$HOME/project/src"
-            cd $EXTENSION
-            PHP_PREFIX=$(php-config --prefix)
-            PHP_PREFIX_BIN=$PHP_PREFIX/bin
-            $PHP_PREFIX_BIN/phpize --clean
-            $PHP_PREFIX_BIN/phpize
-            ./configure --with-php-config=$PHP_PREFIX_BIN/php-config
-            /bin/bash $EXTENSION/libtool --mode=compile $CXX -I. -I$EXTENSION -DPHP_ATOM_INC -I$EXTENSION/include -I$EXTENSION/main -I$EXTENSION -I$PHP_PREFIX/include/php -I$PHP_PREFIX/include/php/main -I$PHP_PREFIX/include/php/TSRM -I$PHP_PREFIX/include/php/Zend -I$PHP_PREFIX/include/php/ext -I$PHP_PREFIX/include/php/ext/date/lib -DHAVE_CONFIG_H -c $EXTENSION/wasm.cc -o wasm.lo -fPIC
-            $CXX -I. -I$EXTENSION -DPHP_ATOM_INC -I$EXTENSION/include -I$EXTENSION/main -I$EXTENSION -I$PHP_PREFIX/include/php -I$PHP_PREFIX/include/php/main -I$PHP_PREFIX/include/php/TSRM -I$PHP_PREFIX/include/php/Zend -I$PHP_PREFIX/include/php/ext -I$PHP_PREFIX/include/php/ext/date/lib -DHAVE_CONFIG_H -c $EXTENSION/wasm.cc  -DPIC -o .libs/wasm.o -fPIC
-            /bin/bash $EXTENSION/libtool --mode=link cc -DPHP_ATOM_INC -I$EXTENSION/include -I$EXTENSION/main -I$EXTENSION -I$PHP_PREFIX/include/php -I$PHP_PREFIX/include/php/main -I$PHP_PREFIX/include/php/TSRM -I$PHP_PREFIX/include/php/Zend -I$PHP_PREFIX/include/php/ext -I$PHP_PREFIX/include/php/ext/date/lib  -DHAVE_CONFIG_H  -g -O2    -o wasm.la -export-dynamic -avoid-version -prefer-pic -module -rpath $EXTENSION/modules  wasm.lo -Wl,-rpath,$EXTENSION/. -L$EXTENSION/. -lwasmer_runtime_c_api -fPIC
-            cc -shared  .libs/wasm.o  -L$EXTENSION/. -lwasmer_runtime_c_api  -Wl,-rpath -Wl,$EXTENSION/. -Wl,-soname -Wl,wasm.so -o .libs/wasm.so -fPIC
-            sudo make install-modules
-
-      # Run the extension test suites.
-      - run:
-          name: Test the extension
-          command: |
-            export PATH="$HOME/.cargo/bin:$PATH"
-            composer install --no-progress
-            vendor/bin/atoum --php 'php -d extension=wasm' --directories tests/units --force-terminal --use-dot-report
+  # Build and test the project the project against PHP 7.2.
+  build_and_test_php_7.2:
+    docker:
+      - image: circleci/php:7.2
+    steps: *build_and_test_steps
 
 
 # List of workflows.
@@ -69,8 +78,8 @@ workflows:
   # The build workflow.
   build:
     jobs:
-      # Run the `build_and_test` job for all branches and all tags.
-      - build_and_test:
+      # Run the `build_and_test_php_latest` job for all branches and all tags.
+      - build_and_test_php_latest: &build_and_test_php_latest
           filters:
             branches:
               only:
@@ -78,3 +87,6 @@ workflows:
                 - staging
             tags:
               only: /.*/
+
+      # Run the `build_and_test_php_7.2` job for all branches and all tags.
+      - build_and_test_php_7.2: *build_and_test_php_latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
     steps: *build_and_test_steps
 
   # Build and test the project the project against PHP 7.2.
-  build_and_test_php_7.2:
+  build_and_test_php_7_2:
     docker:
       - image: circleci/php:7.2
     steps: *build_and_test_steps
@@ -88,5 +88,5 @@ workflows:
             tags:
               only: /.*/
 
-      # Run the `build_and_test_php_7.2` job for all branches and all tags.
-      - build_and_test_php_7.2: *build_and_test_php_latest
+      # Run the `build_and_test_php_7_2` job for all branches and all tags.
+      - build_and_test_php_7_2: *build_and_test_php_latest

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
     "ci/circleci: build_and_test_php_latest",
-    "ci/circleci: build_and_test_php_7.2"
+    "ci/circleci: build_and_test_php_7_2"
 ]
 required_approvals = 0
 timeout_sec = 900

--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,7 @@
-status = [ "ci/circleci: build_and_test" ]
+status = [
+    "ci/circleci: build_and_test_php_latest",
+    "ci/circleci: build_and_test_php_7.2"
+]
 required_approvals = 0
 timeout_sec = 900
 delete_merged_branches = true 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "chat": "https://spectrum.chat/wasmer"
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.2",
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {

--- a/src/wasm.cc
+++ b/src/wasm.cc
@@ -239,7 +239,9 @@ public:
 
     ~wasm_lazy_byte_array_t()
     {
-        efree((uint8_t *) byte_array->bytes);
+        if (byte_array != NULL) {
+            efree((uint8_t *) byte_array->bytes);
+        }
     }
 
     wasmer_byte_array *get_bytes()

--- a/src/wasm.hh
+++ b/src/wasm.hh
@@ -48,7 +48,7 @@
  * `ZEND_ACC_IMMUTABLE` has been defined in PHP 7.3. Be compatible
  * with PHP 7.2 by defining an empty value.
  */
-#ifndef ZEND_ACC_IMMUTABLE
+#if !defined(ZEND_ACC_IMMUTABLE)
 # define ZEND_ACC_IMMUTABLE 0
 #endif
 
@@ -56,7 +56,7 @@
  * `ZEND_PARSE_PARAMETERS_NONE` has been defined in PHP 7.3. Be
  * compatible with PHP 7.2 by copy-pasting its definition.
  */
-#ifndef ZEND_PARSE_PARAMETERS_NONE
+#if !defined(ZEND_PARSE_PARAMETERS_NONE)
 # define ZEND_PARSE_PARAMETERS_NONE() \
     ZEND_PARSE_PARAMETERS_START(0, 0) \
     ZEND_PARSE_PARAMETERS_END()

--- a/src/wasm.hh
+++ b/src/wasm.hh
@@ -35,6 +35,14 @@
 #  include <stdint.h>
 #endif
 
+/**
+ * `ZEND_ACC_IMMUTABLE` has been defined in PHP 7.3. Be compatible
+ * with PHP 7.2 by defining an empty value.
+ */
+#ifndef ZEND_ACC_IMMUTABLE
+# define ZEND_ACC_IMMUTABLE 0
+#endif
+
 // Constant to represent a not nullable (return) type.
 #define NOT_NULLABLE 0
 

--- a/src/wasm.hh
+++ b/src/wasm.hh
@@ -43,6 +43,16 @@
 # define ZEND_ACC_IMMUTABLE 0
 #endif
 
+/**
+ * `ZEND_PARSE_PARAMETERS_NONE` has been defined in PHP 7.3. Be
+ * compatible with PHP 7.2 by copy-pasting its definition.
+ */
+#ifndef ZEND_PARSE_PARAMETERS_NONE
+# define ZEND_PARSE_PARAMETERS_NONE() \
+    ZEND_PARSE_PARAMETERS_START(0, 0) \
+    ZEND_PARSE_PARAMETERS_END()
+#endif
+
 // Constant to represent a not nullable (return) type.
 #define NOT_NULLABLE 0
 

--- a/src/wasm.hh
+++ b/src/wasm.hh
@@ -36,6 +36,15 @@
 #endif
 
 /**
+ * `_IS_NUBMER` has been defined in PHP 7.3. Be compatible with PHP
+ * 7.2 by defining the real value. It will have no effect, but the
+ * code will compile.
+ */
+#if !defined(_IS_NUMBER)
+# define _IS_NUMBER 20
+#endif
+
+/**
  * `ZEND_ACC_IMMUTABLE` has been defined in PHP 7.3. Be compatible
  * with PHP 7.2 by defining an empty value.
  */

--- a/src/wasm.hh
+++ b/src/wasm.hh
@@ -62,6 +62,25 @@
     ZEND_PARSE_PARAMETERS_END()
 #endif
 
+/**
+ * `zend_register_persistent_resource_ex` has been added in PHP 7.3
+ * (see
+ * https://github.com/php/php-src/commit/67d5f39a47b15e28293d9d6558b80ded049179fe). Be
+ * compatible with PHP 7.2 by writing a small hack that should work.
+ */
+#if PHP_VERSION_ID < 70300
+ZEND_API zend_resource* zend_register_persistent_resource_ex(zend_string *key, void *rsrc_pointer, int rsrc_type)
+{
+    zval *zv;
+    zval tmp;
+
+    ZVAL_NEW_PERSISTENT_RES(&tmp, -1, rsrc_pointer, rsrc_type);
+    zv = zend_hash_update(&EG(persistent_list), key, &tmp);
+
+    return Z_RES_P(zv);
+}
+#endif
+
 // Constant to represent a not nullable (return) type.
 #define NOT_NULLABLE 0
 

--- a/tests/units/Extension/Classes.php
+++ b/tests/units/Extension/Classes.php
@@ -258,7 +258,7 @@ class Classes extends Suite
                 ->let($return_type = $methods[3]->getReturnType())
 
                 ->string($return_type . '')
-                    ->isEqualTo('number')
+                    ->isEqualTo(PHP_VERSION_ID < 70300 ? 'unknown' : 'number')
                 ->boolean($return_type->allowsNull())
                     ->isFalse()
 
@@ -412,7 +412,7 @@ class Classes extends Suite
         $this
             ->given(
                 $byteLength = 1114112,
-                $wasmArrayBuffer = new WasmArrayBuffer($byteLength),
+                $wasmArrayBuffer = new WasmArrayBuffer($byteLength)
             )
             ->when($result = $wasmArrayBuffer->grow(1))
             ->then
@@ -655,7 +655,7 @@ class Classes extends Suite
             ->given(
                 $wasmArrayBuffer = new WasmArrayBuffer($wasmTypedArrayClassName::BYTES_PER_ELEMENT),
                 $wasmTypedArray = new $wasmTypedArrayClassName($wasmArrayBuffer),
-                $wasmTypedArray[0] = 42,
+                $wasmTypedArray[0] = 42
             )
             ->when($result = $wasmTypedArray[0])
             ->then

--- a/tests/units/Extension/Functions.php
+++ b/tests/units/Extension/Functions.php
@@ -282,7 +282,7 @@ class Functions extends Suite
                 ->let($return_type = $_result->getReturnType())
 
                 ->string($return_type . '')
-                    ->isEqualTo('number')
+                    ->isEqualTo(PHP_VERSION_ID < 70300 ? 'unknown' : 'number')
                 ->boolean($return_type->allowsNull())
                     ->isTrue()
 


### PR DESCRIPTION
Fix #73.

Currently, the extension is compatible with PHP 7.3. It uses the latest API possible. This set of patches adds support for prior PHP versions, essentially PHP 7.2, since 7.1 is already in security fix only mode (see [the supported versions train](https://www.php.net/supported-versions.php)). 