### PR TITLE
fix(example) Account for null in allocation size.

### DIFF
--- a/examples/greet.php
+++ b/examples/greet.php
@@ -44,5 +44,5 @@ $length_of_output = $nth;
 echo $output, "\n";
 
 // Deallocate the subject, and the output.
-$instance->deallocate($input_pointer, $length_of_subject);
-$instance->deallocate($output_pointer, $length_of_output);
+$instance->deallocate($input_pointer, $length_of_subject+1);
+$instance->deallocate($output_pointer, $length_of_output+1);

--- a/examples/greet.php
+++ b/examples/greet.php
@@ -12,7 +12,7 @@ $subject = 'Wasmer 🐘';
 $length_of_subject = strlen($subject);
 
 // Allocate memory for the subject, and get a pointer to it.
-$input_pointer = $instance->allocate($length_of_subject);
+$input_pointer = $instance->allocate($length_of_subject+1);
 
 // Write the subject into the memory.
 $memory_buffer = $instance->getMemoryBuffer();


### PR DESCRIPTION
The potential issue won't be seen in the greet example, but could cause issues for those who just copy and paste the code. Perhaps there should be a comment explaining the `+1`?

Example of issue: Assume two allocations A and B next to each other in memory, where A doesn't account for the null in its size. If A is written first, then B, attempting to read A will result in a concatenation of the two. If B is written first, attempting to read B will result in an empty string. 