### PR TITLE
Fix missing include directory in extension

### DIFF
--- a/ext/config.m4
+++ b/ext/config.m4
@@ -17,5 +17,7 @@ if test "$PHP_WASM" != "no"; then
 
     PHP_NEW_EXTENSION(wasm, $WASMER_ALL_SOURCES, $ext_shared,, $WASMER_CFLAGS)
 
+    PHP_ADD_INCLUDE([PHP_EXT_SRCDIR()/include])
+
     PHP_ADD_MAKEFILE_FRAGMENT
 fi


### PR DESCRIPTION
With PHP 8.4 the 'include' directory in extensions isn't included automatically. It was part of the PHP_DEFINE macro. This fixes the build for the possible future versions.